### PR TITLE
OCamlformat: module-item-spacing = compact

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -3,3 +3,4 @@ profile = conventional
 parse-docstrings
 break-infix = fit-or-vertical
 indicate-multiline-delimiters = no
+module-item-spacing = compact

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -68,30 +68,20 @@ end
 (** Generators for random data *)
 module Faker = struct
   let () = Random.self_init ()
-
   let unit () = ()
 
   let bool () =
     match Random.int 2 with 0 -> false | 1 -> true | _ -> assert false
 
   let char_int () = Random.int (1 lsl 8)
-
   let short_int () = (1 lsl 8) + Random.int (1 lsl 8)
-
   let long_int () = (1 lsl 16) + Random.int (1 lsl 16)
-
   let int32 () = Random.int32 Int32.max_int
-
   let int64 () = Random.int64 Int64.max_int
-
   let char () = char_of_int (Random.int 256)
-
   let string n () = String.init n (fun _i -> char ())
-
   let bytes n () = Bytes.init n (fun _i -> char ())
-
   let pair a b () = (a (), b ())
-
   let triple a b c () = (a (), b (), c ())
 
   type record = { foo : string; bar : int64; baz : bool * unit }
@@ -113,11 +103,9 @@ module Faker = struct
   type fixed_string = string
 
   let fixed_string_t = T.string_of (`Fixed 5)
-
   let fixed_string () = string 5 ()
 
   type 'a node = { left : 'a; v : fixed_string; right : 'a } [@@deriving repr]
-
   type tree = Branch of tree node | Leaf of int [@@deriving repr]
 
   let tree () =
@@ -160,21 +148,13 @@ module Data = struct
       E { typ; random; encoded }
 
     let unit = mk_data T.unit Faker.unit
-
     let bool = mk_data T.bool Faker.bool
-
     let string_1024 = mk_data T.string Faker.(string 1024)
-
     let bytes_1024 = mk_data T.bytes Faker.(bytes 1024)
-
     let char_int = mk_data T.int Faker.char_int
-
     let short_int = mk_data T.int Faker.short_int
-
     let long_int = mk_data T.int Faker.long_int
-
     let int32 = mk_data T.int32 Faker.int32
-
     let int64 = mk_data T.int64 Faker.int64
 
     let pair_string_int =
@@ -186,9 +166,7 @@ module Data = struct
         Faker.(triple short_int short_int short_int)
 
     let record = mk_data Faker.record_t Faker.record
-
     let variant = mk_data Faker.variant_t Faker.variant
-
     let tree = mk_data Faker.tree_t Faker.tree
   end
 end

--- a/fuzz/main.ml
+++ b/fuzz/main.ml
@@ -2,9 +2,7 @@ open Crowbar
 module T = Repr
 
 let ( |+ ) = T.( |+ )
-
 let ( |~ ) = T.( |~ )
-
 let fmt = Format.sprintf
 
 (* This is part of the standard library as of 4.08 (see [Option.map]). *)
@@ -17,11 +15,8 @@ let result_map fa fe r =
 (* This has to be upstreamed to Crowbar. In the meantime, you can run:
    {v opam pin crowbar https://github.com/stedolan/crowbar.git#master v}. *)
 let char = map [ bytes_fixed 1 ] (fun s -> s.[0])
-
 let string = bytes
-
 let bytes = map [ string ] Bytes.of_string
-
 let triple a b c = map [ a; b; c ] (fun a b c -> (a, b, c))
 
 (* Untyped internal representation of Irmin values. *)

--- a/fuzz/rewriter/main.ml
+++ b/fuzz/rewriter/main.ml
@@ -7,19 +7,16 @@ open Ppxlib
 
 module type S = sig
   val impl_record : int -> expression
-
   val impl_variant : int -> expression
 end
 
 let ( >>| ) x f = List.map f x
-
 let ( >>= ) x f = List.map f x |> List.flatten
 
 module Located (A : Ast_builder.S) : S = struct
   open A
 
   let ev n i = evar (n ^ string_of_int i)
-
   let pv n i = pvar (n ^ string_of_int i)
 
   let plist : pattern list -> pattern =

--- a/src/ppx_repr/bin/ppx_repr.ml
+++ b/src/ppx_repr/bin/ppx_repr.ml
@@ -16,7 +16,6 @@
 
 module Plugins = Ppx_repr_lib.Plugins.Make (struct
   let default_library = "Repr"
-
   let namespace = "repr"
 end)
 

--- a/src/ppx_repr/lib/algebraic.ml
+++ b/src/ppx_repr/lib/algebraic.ml
@@ -21,9 +21,7 @@ open Ppxlib
 module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
   module M = M
   open Utils
-
   open Utils.Make (A)
-
   open A
 
   let generate_identifiers n =

--- a/src/ppx_repr/lib/attributes_intf.ml
+++ b/src/ppx_repr/lib/attributes_intf.ml
@@ -2,7 +2,6 @@ open Ppxlib
 
 module type S = sig
   val repr : (core_type, expression) Attribute.t
-
   val nobuiltin : (core_type, unit) Attribute.t
 end
 

--- a/src/ppx_repr/lib/engine.ml
+++ b/src/ppx_repr/lib/engine.ml
@@ -57,9 +57,7 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
     f_ref := f_new
 
   open Utils
-
   open Utils.Make (A)
-
   module Reader = Monad.Reader
 
   module Algebraic = struct
@@ -78,7 +76,6 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
     [%expr [%e mu] (fun [%p pvar fparam] -> [%e e])]
 
   let repr_name_of_type_name = function "t" -> "t" | x -> x ^ "_t"
-
   let in_lib ~lib x = match lib with Some lib -> lib ^ "." ^ x | None -> x
 
   let contains_tvar tvar typ =

--- a/src/ppx_repr/lib/monad.ml
+++ b/src/ppx_repr/lib/monad.ml
@@ -20,11 +20,8 @@ module Reader = struct
   type ('a, 'e) t = Reader of ('e -> 'a)
 
   let run (Reader r) = r
-
   let map f m = Reader (fun env -> f (run m env))
-
   let bind f m = Reader (fun env -> run (f (run m env)) env)
-
   let return x = Reader (fun _ -> x)
 
   let sequence (type a e) ms =
@@ -34,14 +31,11 @@ module Reader = struct
       ms (return [])
 
   let asks f = Reader (fun env -> f env)
-
   let ask = Reader (fun env -> env)
-
   let local f m = Reader (fun env -> run m (f env))
 
   module Syntax = struct
     let ( let+ ) x f = map f x
-
     let ( let* ) x f = bind f x
   end
 end

--- a/src/ppx_repr/lib/monad_intf.ml
+++ b/src/ppx_repr/lib/monad_intf.ml
@@ -18,16 +18,12 @@ module type S = sig
   type ('a, 'p) t
 
   val return : 'a -> ('a, 'p) t
-
   val map : ('a -> 'b) -> ('a, 'p) t -> ('b, 'p) t
-
   val bind : ('a -> ('b, 'p) t) -> ('a, 'p) t -> ('b, 'p) t
-
   val sequence : ('a, 'p) t list -> ('a list, 'p) t
 
   module Syntax : sig
     val ( let+ ) : ('a, 'p) t -> ('a -> 'b) -> ('b, 'p) t
-
     val ( let* ) : ('a, 'p) t -> ('a -> ('b, 'p) t) -> ('b, 'p) t
   end
 end

--- a/src/ppx_repr/lib/plugins.ml
+++ b/src/ppx_repr/lib/plugins.ml
@@ -18,7 +18,6 @@ open Ppxlib
 
 module Make (T : sig
   val namespace : string
-
   val default_library : string
 end) =
 struct

--- a/src/ppx_repr/lib/plugins.mli
+++ b/src/ppx_repr/lib/plugins.mli
@@ -16,10 +16,8 @@
 
 module Make (T : sig
   val namespace : string
-
   val default_library : string
 end) : sig
   val register_deriver : unit -> unit
-
   val register_extension : ?no_reserve_namespace:unit -> unit -> unit
 end

--- a/src/ppx_repr/lib/raise.mli
+++ b/src/ppx_repr/lib/raise.mli
@@ -18,20 +18,12 @@ open Ppxlib
 
 module Unsupported : sig
   val tuple_size : loc:location -> int -> _
-
   val type_arrow : loc:location -> core_type -> _
-
   val type_open : loc:location -> _
-
   val type_poly : loc:location -> core_type -> _
-
   val type_open_polyvar : loc:location -> core_type -> _
-
   val type_package : loc:location -> core_type -> _
-
   val type_extension : loc:location -> core_type -> _
-
   val type_alias : loc:location -> core_type -> _
-
   val type_any : loc:location -> _
 end

--- a/src/ppx_repr/lib/utils.ml
+++ b/src/ppx_repr/lib/utils.ml
@@ -1,7 +1,6 @@
 open Ppxlib
 
 let ( >> ) f g x = g (f x)
-
 let ( >|= ) x f = List.map f x
 
 module Make (A : Ast_builder.S) : sig
@@ -17,8 +16,6 @@ end = struct
   open A
 
   let compose_all l x = List.fold_left ( |> ) x (List.rev l)
-
   let lambda = List.map (pvar >> pexp_fun Nolabel None) >> compose_all
-
   let arrow = List.map (ptyp_arrow Nolabel) >> compose_all
 end

--- a/src/repr/staging.ml
+++ b/src/repr/staging.ml
@@ -1,5 +1,4 @@
 type +'a staged = 'a
 
 let stage x = x
-
 let unstage x = x

--- a/src/repr/staging.mli
+++ b/src/repr/staging.mli
@@ -3,5 +3,4 @@
 type +'a staged
 
 val stage : 'a -> 'a staged
-
 val unstage : 'a staged -> 'a

--- a/src/repr/type.ml
+++ b/src/repr/type.ml
@@ -43,37 +43,21 @@ let short_hash = function
 (* Combinators for Irmin types *)
 
 let unit = Prim Unit
-
 let bool = Prim Bool
-
 let char = Prim Char
-
 let int = Prim Int
-
 let int32 = Prim Int32
-
 let int64 = Prim Int64
-
 let float = Prim Float
-
 let string = Prim (String `Int)
-
 let bytes = Prim (Bytes `Int)
-
 let string_of n = Prim (String n)
-
 let bytes_of n = Prim (Bytes n)
-
 let list ?(len = `Int) v = List { v; len }
-
 let array ?(len = `Int) v = Array { v; len }
-
 let pair a b = Tuple (Pair (a, b))
-
 let triple a b c = Tuple (Triple (a, b, c))
-
 let option a = Option a
-
 let boxed t = Boxed t
 
 let v ~pp ~of_string ~json ~bin ?unboxed_bin ~equal ~compare ~short_hash
@@ -184,7 +168,6 @@ let ( |+ ) = app
 (* variants *)
 
 type 'a case_p = 'a case_v
-
 type ('a, 'b) case = int -> 'a a_case * 'b
 
 let case0 cname0 c0 =

--- a/src/repr/type_binary.ml
+++ b/src/repr/type_binary.ml
@@ -20,21 +20,13 @@ open Utils
 
 module B = struct
   external get_16 : string -> int -> int = "%caml_string_get16"
-
   external get_32 : string -> int -> int32 = "%caml_string_get32"
-
   external get_64 : string -> int -> int64 = "%caml_string_get64"
-
   external set_16 : Bytes.t -> int -> int -> unit = "%caml_string_set16u"
-
   external set_32 : Bytes.t -> int -> int32 -> unit = "%caml_string_set32u"
-
   external set_64 : Bytes.t -> int -> int64 -> unit = "%caml_string_set64u"
-
   external swap16 : int -> int = "%bswap16"
-
   external swap32 : int32 -> int32 = "%bswap_int32"
-
   external swap64 : int64 -> int64 = "%bswap_int64"
 
   let get_uint16 s off =
@@ -58,13 +50,9 @@ end
 
 module Encode = struct
   let unit () _k = ()
-
   let add_bytes b k = k (Bytes.to_string b)
-
   let add_string s k = k s
-
   let char c = add_bytes (Bytes.make 1 c)
-
   let int8 i = char (Char.chr i)
 
   let int16 i =
@@ -83,7 +71,6 @@ module Encode = struct
     add_bytes b
 
   let float f = int64 (Int64.bits_of_float f)
-
   let bool b = char (if b then '\255' else '\000')
 
   let int i k =
@@ -116,7 +103,6 @@ module Encode = struct
       add_string s k
 
   let string boxed = if boxed then boxed_string else unboxed_string
-
   let unboxed_bytes _ = add_bytes
 
   let boxed_bytes n =
@@ -242,7 +228,6 @@ module Decode = struct
   type 'a res = int * 'a
 
   let unit _ ofs = (ofs, ())
-
   let char buf ofs = (ofs + 1, buf.[ofs])
 
   let int8 buf ofs =
@@ -250,9 +235,7 @@ module Decode = struct
     (ofs, Char.code c)
 
   let int16 buf ofs = (ofs + 2, B.get_uint16 buf ofs)
-
   let int32 buf ofs = (ofs + 4, B.get_uint32 buf ofs)
-
   let int64 buf ofs = (ofs + 8, B.get_uint64 buf ofs)
 
   let bool buf ofs =
@@ -313,7 +296,6 @@ module Decode = struct
     fun boxed -> if boxed then f_boxed else f_unboxed
 
   let string = mk (fun x -> x) Bytes.unsafe_to_string
-
   let bytes = mk Bytes.of_string (fun x -> x)
 
   let list l n =
@@ -452,16 +434,13 @@ module Decode = struct
 end
 
 let encode_bin = Encode.t
-
 let decode_bin = Decode.t
 
 type 'a to_bin_string = 'a to_string staged
-
 type 'a of_bin_string = 'a of_string staged
 
 module Unboxed = struct
   let encode_bin = Encode.unboxed
-
   let decode_bin = Decode.unboxed
 end
 

--- a/src/repr/type_binary.mli
+++ b/src/repr/type_binary.mli
@@ -18,15 +18,12 @@ open Type_core
 open Staging
 
 val encode_bin : 'a t -> 'a encode_bin
-
 val decode_bin : 'a t -> 'a decode_bin
 
 module Unboxed : sig
   val encode_bin : 'a t -> 'a encode_bin
-
   val decode_bin : 'a t -> 'a decode_bin
 end
 
 val to_bin_string : 'a t -> 'a to_string staged
-
 val of_bin_string : 'a t -> 'a of_string staged

--- a/src/repr/type_core.ml
+++ b/src/repr/type_core.ml
@@ -22,9 +22,7 @@ module Json = struct
   type decoder = json_decoder
 
   let decoder ?encoding src = { lexemes = []; d = Jsonm.decoder ?encoding src }
-
   let decoder_of_lexemes lexemes = { lexemes; d = Jsonm.decoder (`String "") }
-
   let rewind e l = e.lexemes <- l :: e.lexemes
 
   let decode e =

--- a/src/repr/type_core_intf.ml
+++ b/src/repr/type_core_intf.ml
@@ -2,33 +2,19 @@ open Staging
 
 module Types = struct
   type len = [ `Int | `Int8 | `Int16 | `Int32 | `Int64 | `Fixed of int ]
-
   type 'a pp = 'a Fmt.t
-
   type 'a of_string = string -> ('a, [ `Msg of string ]) result
-
   type 'a to_string = 'a -> string
-
   type 'a encode_json = Jsonm.encoder -> 'a -> unit
-
   type json_decoder = { mutable lexemes : Jsonm.lexeme list; d : Jsonm.decoder }
-
   type 'a decode_json = json_decoder -> ('a, [ `Msg of string ]) result
-
   type 'a bin_seq = 'a -> (string -> unit) -> unit
-
   type 'a pre_hash = 'a bin_seq staged
-
   type 'a encode_bin = 'a bin_seq staged
-
   type 'a decode_bin = (string -> int -> int * 'a) staged
-
   type 'a size_of = ('a -> int option) staged
-
   type 'a compare = 'a -> 'a -> int
-
   type 'a equal = 'a -> 'a -> bool
-
   type 'a short_hash = ?seed:int -> 'a -> int
 
   type 'a t =
@@ -189,7 +175,6 @@ module type Type_core = sig
       ?encoding:[< Jsonm.encoding ] -> [< Jsonm.src ] -> json_decoder
 
     val decoder_of_lexemes : Jsonm.lexeme list -> json_decoder
-
     val rewind : json_decoder -> Jsonm.lexeme -> unit
 
     val decode :

--- a/src/repr/type_json.ml
+++ b/src/repr/type_json.ml
@@ -47,11 +47,8 @@ module Encode = struct
     | _ -> lexeme e (`Float f)
 
   let int e i = float e (float_of_int i)
-
   let int32 e i = float e (Int32.to_float i)
-
   let int64 e i = float e (Int64.to_float i)
-
   let bool e = function false -> float e 0. | _ -> float e 1.
 
   let list l e x =
@@ -160,7 +157,6 @@ module Decode = struct
     | `End | `Await -> assert false
 
   let ( >>= ) l f = match l with Error _ as e -> e | Ok l -> f l
-
   let ( >|= ) l f = match l with Ok l -> Ok (f l) | Error _ as e -> e
 
   let error e got expected =
@@ -242,11 +238,8 @@ module Decode = struct
     | l -> error e l "`String[0]"
 
   let int32 e = float e >|= Int32.of_float
-
   let int64 e = float e >|= Int64.of_float
-
   let int e = float e >|= int_of_float
-
   let bool e = int e >|= function 0 -> false | _ -> true
 
   let list l e =
@@ -397,9 +390,7 @@ module Decode = struct
 end
 
 let encode = Encode.t
-
 let decode = Decode.t
-
 let decode_jsonm x d = Decode.(t x @@ { d; lexemes = [] })
 
 let pp ?minify t ppf x =
@@ -410,7 +401,5 @@ let pp ?minify t ppf x =
   Fmt.string ppf (Buffer.contents buf)
 
 let to_string ?minify t x = Fmt.to_to_string (pp ?minify t) x
-
 let of_string x s = Decode.(t x @@ Json.decoder (`String s))
-
 let decode_lexemes x ls = Decode.(t x @@ Json.decoder_of_lexemes ls)

--- a/src/repr/type_json.mli
+++ b/src/repr/type_json.mli
@@ -17,15 +17,10 @@
 open Type_core
 
 val pp : ?minify:bool -> 'a t -> 'a Fmt.t
-
 val to_string : ?minify:bool -> 'a t -> 'a to_string
-
 val of_string : 'a t -> 'a of_string
-
 val encode : 'a t -> 'a encode_json
-
 val decode : 'a t -> 'a decode_json
-
 val decode_jsonm : 'a t -> Jsonm.decoder -> ('a, [ `Msg of string ]) result
 
 val decode_lexemes :

--- a/src/repr/type_ordered.ml
+++ b/src/repr/type_ordered.ml
@@ -75,19 +75,12 @@ end
 
 module Equal = struct
   let unit _ _ = true
-
   let bool (x : bool) (y : bool) = x = y
-
   let char (x : char) (y : char) = x = y
-
   let int (x : int) (y : int) = x = y
-
   let int32 (x : int32) (y : int32) = x = y
-
   let int64 (x : int64) (y : int64) = x = y
-
   let string x y = x == y || String.equal x y
-
   let bytes x y = x == y || Bytes.equal x y
 
   (* NOTE: equality is ill-defined on float *)
@@ -184,21 +177,13 @@ end
 
 module Compare = struct
   let unit (_ : unit) (_ : unit) = 0 [@@inline always]
-
   let bool (x : bool) (y : bool) = compare x y [@@inline always]
-
   let char x y = Char.compare x y [@@inline always]
-
   let int (x : int) (y : int) = compare x y [@@inline always]
-
   let int32 x y = Int32.compare x y [@@inline always]
-
   let int64 x y = Int64.compare x y [@@inline always]
-
   let float (x : float) (y : float) = compare x y [@@inline always]
-
   let string x y = if x == y then 0 else String.compare x y [@@inline always]
-
   let bytes x y = if x == y then 0 else Bytes.compare x y [@@inline always]
 
   let list c x y =
@@ -317,5 +302,4 @@ module Compare = struct
 end
 
 let equal = Equal.t
-
 let compare t x y = Compare.t t x y

--- a/src/repr/type_ordered.mli
+++ b/src/repr/type_ordered.mli
@@ -17,5 +17,4 @@
 open Type_core
 
 val equal : 'a t -> 'a equal
-
 val compare : 'a t -> 'a compare

--- a/src/repr/type_pp.mli
+++ b/src/repr/type_pp.mli
@@ -17,11 +17,7 @@
 open Type_core
 
 val t : 'a t -> 'a Fmt.t
-
 val dump : 'a t -> 'a Fmt.t
-
 val ty : 'a t Fmt.t
-
 val to_string : 'a t -> 'a to_string
-
 val of_string : 'a t -> 'a of_string

--- a/src/repr/type_size.ml
+++ b/src/repr/type_size.ml
@@ -19,7 +19,6 @@ open Staging
 open Utils
 
 let ( >>= ) x f = match x with Some x -> f x | None -> None
-
 let ( >|= ) x f = match x with Some x -> Some (f x) | None -> None
 
 let int n =
@@ -37,15 +36,10 @@ let len n = function
   | `Fixed _ -> 0
 
 let unit () = 0
-
 let char (_ : char) = 1
-
 let int32 (_ : int32) = 4
-
 let int64 (_ : int64) = 8
-
 let bool (_ : bool) = 1
-
 let float (_ : float) = 8 (* NOTE: we consider 'double' here *)
 
 let boxed_string n s =

--- a/src/repr/type_size.mli
+++ b/src/repr/type_size.mli
@@ -17,5 +17,4 @@
 open Type_core
 
 val t : 'a t -> 'a size_of
-
 val unboxed : 'a t -> 'a size_of

--- a/src/repr/utils.mli
+++ b/src/repr/utils.mli
@@ -1,7 +1,6 @@
 open Staging
 
 val check_valid_utf8 : string -> unit
-
 val is_valid_utf8 : string -> bool
 
 val fix_staged : ('f -> 'f) -> ((_ -> _) staged as 'f)

--- a/src/repr/witness.ml
+++ b/src/repr/witness.ml
@@ -15,12 +15,10 @@
  *)
 
 type (_, _) eq = Refl : ('a, 'a) eq
-
 type _ equality = ..
 
 module type Inst = sig
   type t
-
   type _ equality += Eq : t equality
 end
 
@@ -30,7 +28,6 @@ let make : type a. unit -> a t =
  fun () ->
   let module Inst = struct
     type t = a
-
     type _ equality += Eq : t equality
   end in
   (module Inst)

--- a/src/repr/witness.mli
+++ b/src/repr/witness.mli
@@ -15,11 +15,8 @@
  *)
 
 type (_, _) eq = Refl : ('a, 'a) eq
-
 type 'a t
 
 val make : unit -> 'a t
-
 val eq : 'a t -> 'b t -> ('a, 'b) eq option
-
 val cast : 'a t -> 'b t -> 'a -> 'b option

--- a/test/ppx_repr/deriver/passing/alias.ml
+++ b/test/ppx_repr/deriver/passing/alias.ml
@@ -1,12 +1,8 @@
 (* Tests of type aliases *)
 type test_result = (int, string) result [@@deriving repr]
-
 type t_alias = test_result [@@deriving repr]
-
 type t = t_alias [@@deriving repr]
 
 let (_ : test_result Repr.t) = test_result_t
-
 let (_ : t_alias Repr.t) = t_alias_t
-
 let (_ : t Repr.t) = t

--- a/test/ppx_repr/deriver/passing/arguments.ml
+++ b/test/ppx_repr/deriver/passing/arguments.ml
@@ -8,7 +8,6 @@ type d = int [@@deriving repr { name = "repr_for_d" }]
 let (_ : d Repr.t) = repr_for_d
 
 type point_elsewhere1 = (c[@repr c_wit]) [@@deriving repr]
-
 type point_elsewhere2 = int * (c[@repr c_wit]) [@@deriving repr]
 
 type point_elsewhere3 = A of int * (c[@repr c_wit]) | B of (c[@repr c_wit])
@@ -23,9 +22,6 @@ type point_elsewhere4 = {
 [@@deriving repr]
 
 let (_ : point_elsewhere1 Repr.t) = point_elsewhere1_t
-
 let (_ : point_elsewhere2 Repr.t) = point_elsewhere2_t
-
 let (_ : point_elsewhere3 Repr.t) = point_elsewhere3_t
-
 let (_ : point_elsewhere4 Repr.t) = point_elsewhere4_t

--- a/test/ppx_repr/deriver/passing/basic.ml
+++ b/test/ppx_repr/deriver/passing/basic.ml
@@ -1,14 +1,8 @@
 (* Tests of the basic types *)
 type test_unit = unit [@@deriving repr]
-
 type test_bool = bool [@@deriving repr]
-
 type test_char = char [@@deriving repr]
-
 type test_int32 = int32 [@@deriving repr]
-
 type test_int64 = int64 [@@deriving repr]
-
 type test_float = float [@@deriving repr]
-
 type test_string = string [@@deriving repr]

--- a/test/ppx_repr/deriver/passing/composite.ml
+++ b/test/ppx_repr/deriver/passing/composite.ml
@@ -1,28 +1,16 @@
 (* Tests of the composite type combinators *)
 type test_list1 = string list [@@deriving repr]
-
 type test_list2 = int32 list list list [@@deriving repr]
-
 type test_array = bool array [@@deriving repr]
-
 type test_option = unit option [@@deriving repr]
-
 type test_pair = string * int32 [@@deriving repr]
-
 type test_triple = string * int32 * bool [@@deriving repr]
-
 type test_result = (int32, string) result [@@deriving repr]
 
 let (_ : test_list1 Repr.t) = test_list1_t
-
 let (_ : test_list2 Repr.t) = test_list2_t
-
 let (_ : test_array Repr.t) = test_array_t
-
 let (_ : test_option Repr.t) = test_option_t
-
 let (_ : test_pair Repr.t) = test_pair_t
-
 let (_ : test_triple Repr.t) = test_triple_t
-
 let (_ : test_result Repr.t) = test_result_t

--- a/test/ppx_repr/deriver/passing/extension.ml
+++ b/test/ppx_repr/deriver/passing/extension.ml
@@ -8,7 +8,6 @@ module Alias = struct
   type t = unit
 
   let t = Repr.unit
-
   let (_ : unit typ) = [%typ: t]
 end
 
@@ -18,9 +17,7 @@ end
 
 module Params = struct
   let __ : type a. a typ -> a list typ = [%typ: 'a list]
-
   let __ : type a b. a typ -> b typ -> (a * b * a) typ = [%typ: 'a * _ * 'a]
-
   let __ : type a b. a typ -> b typ -> (a, b) result typ = [%typ: (_, _) result]
 end
 

--- a/test/ppx_repr/deriver/passing/lib_relocated.ml
+++ b/test/ppx_repr/deriver/passing/lib_relocated.ml
@@ -4,7 +4,6 @@ module Elsewhere : sig
   type t [@@deriving repr { lib = Some "Foo" }]
 end = struct
   module Foo = Repr
-
   module Irmin = struct end
 
   type t = unit * unit [@@deriving repr { lib = Some "Foo" }]
@@ -12,7 +11,6 @@ end
 
 module Locally_avaliable : sig
   type 'a ty
-
   type t [@@deriving repr { lib = None }]
 end = struct
   let pair, unit = Repr.(pair, unit)

--- a/test/ppx_repr/deriver/passing/module.ml
+++ b/test/ppx_repr/deriver/passing/module.ml
@@ -9,10 +9,7 @@ module ModuleQualifiedTypes = struct
   end
 
   type t = X.t [@@deriving repr]
-
   type t_result = (X.t, unit) result [@@deriving repr]
-
   type foo = Y.foo [@@deriving repr]
-
   type foo_list = Y.foo list [@@deriving repr]
 end

--- a/test/ppx_repr/deriver/passing/nobuiltin.ml
+++ b/test/ppx_repr/deriver/passing/nobuiltin.ml
@@ -22,9 +22,7 @@ end
 module Nobuiltin_operator = struct
   (* Define our own representation of [result]. *)
   let result_t a b = Repr.pair a b
-
   let int32_t = Repr.int
-
   let int64_t = Repr.bool
 
   type u = (((int32[@nobuiltin]), int64) result[@nobuiltin]) [@@deriving repr]

--- a/test/ppx_repr/deriver/passing/nonrec.ml
+++ b/test/ppx_repr/deriver/passing/nonrec.ml
@@ -1,25 +1,20 @@
 type t = unit [@@deriving repr]
-
 type t_alias = unit [@@deriving repr]
 
 (* Ensure that 'nonrec' assertions are respected *)
 module S1 : sig
   type nonrec t = t list [@@deriving repr]
-
   type nonrec t_alias = t_alias list [@@deriving repr]
 end = struct
   type nonrec t = t list [@@deriving repr]
-
   type nonrec t_alias = t_alias list [@@deriving repr]
 end
 
 (* Now test the interaction of 'nonrec' with custom naming *)
 module S2 : sig
   type nonrec t = t list [@@deriving repr { name = "t_repr" }]
-
   type nonrec t_alias = t_alias list [@@deriving repr { name = "t_repr" }]
 end = struct
   type nonrec t = t list [@@deriving repr { name = "t_repr" }]
-
   type nonrec t_alias = t_alias list [@@deriving repr { name = "t_repr" }]
 end

--- a/test/ppx_repr/deriver/passing/signature.ml
+++ b/test/ppx_repr/deriver/passing/signature.ml
@@ -1,9 +1,7 @@
 (* Tests of the signature deriver *)
 module SigTests : sig
   type t = string [@@deriving repr]
-
   type foo = unit [@@deriving repr { name = "foo_repr" }]
-
   type my_int = int32 * t [@@deriving repr]
 
   type my_variant =
@@ -13,9 +11,7 @@ module SigTests : sig
   [@@deriving repr]
 end = struct
   type t = string [@@deriving repr]
-
   type foo = unit [@@deriving repr { name = "foo_repr" }]
-
   type my_int = int32 * t [@@deriving repr]
 
   type my_variant =

--- a/test/ppx_repr/deriver/passing/variant.ml
+++ b/test/ppx_repr/deriver/passing/variant.ml
@@ -1,10 +1,7 @@
 (* Variants *)
 type test_variant1 = A [@@deriving repr]
-
 type test_variant2 = A2 of int64 [@@deriving repr]
-
 type test_variant3 = A3 of string * test_variant2 [@@deriving repr]
-
 type test_variant4 = A4 | B4 | C4 [@@deriving repr]
 
 type test_variant5 =

--- a/test/repr/main.ml
+++ b/test/repr/main.ml
@@ -3,17 +3,12 @@ module T = Repr
 let id x = x
 
 type foo = { a : int; b : int }
-
 type bar = { c : int option; d : int option option }
 
 let to_bin_string t = T.unstage (T.to_bin_string t)
-
 let of_bin_string t = T.unstage (T.of_bin_string t)
-
 let encode_bin t = T.unstage (T.encode_bin t)
-
 let decode_bin t = T.unstage (T.decode_bin t)
-
 let size_of t = T.unstage (T.size_of t)
 
 let with_buf f =
@@ -23,9 +18,7 @@ let with_buf f =
 
 module Unboxed = struct
   let decode_bin t = T.unstage (T.Unboxed.decode_bin t)
-
   let encode_bin t = T.unstage (T.Unboxed.encode_bin t)
-
   let size_of t = T.unstage (T.Unboxed.size_of t)
 end
 
@@ -78,7 +71,6 @@ let pp_hex ppf s =
   Fmt.string ppf x
 
 let of_hex_string x = Ok (Hex.to_string (`Hex x))
-
 let hex = T.map T.string ~pp:pp_hex ~of_string:of_hex_string id id
 
 let hex2 =
@@ -111,7 +103,6 @@ let hex2 =
   T.map T.string ~json:(encode_json, decode_json) id id
 
 let error = Alcotest.testable (fun ppf (`Msg e) -> Fmt.string ppf e) ( = )
-
 let ok x = Alcotest.result x error
 
 let test_json () =
@@ -244,7 +235,6 @@ module Algebraic = struct
   (* Dummy algebraic types and corresponding type representations *)
 
   type my_enum = Alpha | Beta | Gamma | Delta [@@deriving repr]
-
   type my_variant = Left of int | Right of int list [@@deriving repr]
 
   type my_recursive_variant =
@@ -524,9 +514,7 @@ let test_pp_ty () =
         ~pre_hash:s2 ()
 
     let like_prim : int T.t = T.(like int)
-
     let like_custom : empty T.t = T.like v
-
     let map : int T.t = T.(map int) (fun x -> x) (fun x -> x)
   end in
   test ~case_name:"custom v" Custom.v "Custom (-)";


### PR DESCRIPTION
There are a lot of small definitions in this repository, which I think makes it a good candidate for this option.