### PR TITLE
Use JSON Booleans

### DIFF
--- a/src/repr/type_json.ml
+++ b/src/repr/type_json.ml
@@ -49,7 +49,7 @@ module Encode = struct
   let int e i = float e (float_of_int i)
   let int32 e i = float e (Int32.to_float i)
   let int64 e i = float e (Int64.to_float i)
-  let bool e = function false -> float e 0. | _ -> float e 1.
+  let bool e b = lexeme e (`Bool b)
 
   let list l e x =
     lexeme e `As;
@@ -240,7 +240,7 @@ module Decode = struct
   let int32 e = float e >|= Int32.of_float
   let int64 e = float e >|= Int64.of_float
   let int e = float e >|= int_of_float
-  let bool e = int e >|= function 0 -> false | _ -> true
+  let bool e = lexeme e >>= function `Bool b -> Ok b | l -> error e l "`Bool"
 
   let list l e =
     expect_lexeme e `As >>= fun () ->

--- a/test/repr/main.ml
+++ b/test/repr/main.ml
@@ -300,13 +300,13 @@ let test_to_string () =
     (Some None) "{\"some\":null}";
   test "(int * string * bool)"
     T.(triple int string bool)
-    (1, "foo", true) "[1,\"foo\",1]";
+    (1, "foo", true) "[1,\"foo\",true]";
   test "(string, bool) result{ok}"
     T.(result string bool)
     (Ok "foo") "{\"ok\":\"foo\"}";
   test "(string, bool) result{error}"
     T.(result string bool)
-    (Error false) "{\"error\":0}";
+    (Error false) "{\"error\":false}";
 
   (* Test cases for algebraic combinators *)
   let open Algebraic in
@@ -317,7 +317,7 @@ let test_to_string () =
     "{\"Branch\":[{\"Branch\":[{\"Leaf\":1}]},{\"Leaf\":2}]}";
   test "record" my_record_t
     { foo = 2; flag = false; letter = Delta }
-    "{\"foo\":2,\"flag\":0,\"letter\":\"Delta\"}";
+    "{\"foo\":2,\"flag\":false,\"letter\":\"Delta\"}";
 
   test "recursive record" my_recursive_record_t
     { head = 1; tail = Some { head = 2; tail = None } }


### PR DESCRIPTION
Changes the default JSON encoding of Booleans to use JSON Booleans,
rather than the numbers 0 and 1.

_(Originally PRed at https://github.com/mirage/irmin/pull/1104.)_