### PR TITLE
Add Travis CI and missing internal dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+env:
+  global:
+  - ALCOTEST_SHOW_ERRORS=1
+  - PINS='repr.dev:. repr-bench.dev:. repr-fuzz.dev:. ppx_repr.dev:.'
+  - DISTRO=debian-stable
+  matrix:
+  - OCAML_VERSION=4.08 PACKAGE="repr"
+  - OCAML_VERSION=4.08 PACKAGE="repr-bench"
+  - OCAML_VERSION=4.08 PACKAGE="repr-fuzz"
+  - OCAML_VERSION=4.08 PACKAGE="ppx_repr"

--- a/dune-project
+++ b/dune-project
@@ -11,15 +11,7 @@
 
 (package
  (name repr)
- (depends
-  (ocaml (>= 4.08.0))
-  (fmt (>= 0.8.0))
-  uutf
-  (jsonm (>= 1.0.0))
-  (base64 (>= 2.0.0))
-  (hex :with-test)
-  (alcotest (and (>= 1.1.0) :with-test))
-  (ppx_repr :with-test))
+ (depends) ;; Dune doesn't support generating `post` dependencies
  (synopsis "Dynamic type representaitons. Provides no stability guarantee")
  (description "\
 This package defines a library of combinators for building dynamic type

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,8 @@
   (jsonm (>= 1.0.0))
   (base64 (>= 2.0.0))
   (hex :with-test)
-  (alcotest (and (>= 1.1.0) :with-test)))
+  (alcotest (and (>= 1.1.0) :with-test))
+  (ppx_repr :with-test))
  (synopsis "Dynamic type representaitons. Provides no stability guarantee")
  (description "\
 This package defines a library of combinators for building dynamic type
@@ -40,6 +41,7 @@ guarantee.
  (name repr-bench)
  (depends
   (repr (= :version))
+  (ppx_repr (= :version))
   bechamel
   yojson
   fpath

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.7)
 (generate_opam_files true)
 (allow_approximate_merlin)
+(strict_package_deps)
 
 (name repr)
 (source (github mirage/repr))

--- a/repr-bench.opam
+++ b/repr-bench.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
+  "ppx_repr" {= version}
   "bechamel"
   "yojson"
   "fpath"

--- a/repr.opam
+++ b/repr.opam
@@ -23,6 +23,7 @@ depends: [
   "base64" {>= "2.0.0"}
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
+  "ppx_repr" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/repr.opam
+++ b/repr.opam
@@ -14,18 +14,6 @@ authors: ["Thomas Gazagnaire" "Craig Ferguson"]
 license: "ISC"
 homepage: "https://github.com/mirage/repr"
 bug-reports: "https://github.com/mirage/repr/issues"
-depends: [
-  "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
-  "fmt" {>= "0.8.0"}
-  "uutf"
-  "jsonm" {>= "1.0.0"}
-  "base64" {>= "2.0.0"}
-  "hex" {with-test}
-  "alcotest" {>= "1.1.0" & with-test}
-  "ppx_repr" {with-test}
-  "odoc" {with-doc}
-]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -41,3 +29,15 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/repr.git"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.0"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+  "ppx_repr" {= version & post & with-test}
+]

--- a/repr.opam.template
+++ b/repr.opam.template
@@ -1,0 +1,12 @@
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.0"}
+  "uutf"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "2.0.0"}
+  "hex" {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "odoc" {with-doc}
+  "ppx_repr" {= version & post & with-test}
+]


### PR DESCRIPTION
The attempt to release `0.1.0` revealed a missing internal dependency (https://github.com/ocaml/opam-repository/pull/17410). This sort of failure is not picked up by OCaml-CI, so I'm adding Travis CI to this repository too.