### PR TITLE
Make ppx_repr compatible with ppxlib.0.18.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@ guarantee.
  (name ppx_repr)
  (depends
   (repr (= :version))
-  (ppxlib (and (>= 0.12.0) (< 0.18.0)))
+  (ppxlib (>= 0.18.0))
   ; Test dependencies inherited from [repr] (see [test/repr/dune])
   (hex :with-test)
   (alcotest (and (>= 1.1.0) :with-test)))
@@ -55,7 +55,7 @@ guarantee.
  (depends
   (repr (= :version))
   (crowbar (= 0.2))
-  (ppxlib (and (>= 0.12.0) (< 0.18.0))))
+  (ppxlib (>= 0.18.0)))
  (synopsis "Fuzz tests for the `repr` package")
  (description "Fuzz tests for the `repr` package"))
   

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
-  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "ppxlib" {>= "0.18.0"}
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}

--- a/repr-fuzz.opam
+++ b/repr-fuzz.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
   "crowbar" {= "0.2"}
-  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "ppxlib" {>= "0.18.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/ppx_repr/lib/engine.ml
+++ b/src/ppx_repr/lib/engine.ml
@@ -266,7 +266,8 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
      pexp_desc =
        Pexp_construct
          ( { txt = Lident "Some"; _ },
-           Some { pexp_desc = Pexp_constant (Pconst_string (lib, None)); _ } );
+           Some { pexp_desc = Pexp_constant (Pconst_string (lib, _, None)); _ }
+         );
      _;
     } ->
         Some lib


### PR DESCRIPTION
ppxlib.0.18.0 upgraded its AST to 4.11 which lead to a change in string
constant representation. This PR make `ppx_repr` compatible with the newest
ppxlib.