### PR TITLE
Fix fmt constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
-### Unreleased
+### 0.2.0 (2020-12-18)
 
+- Improve performance of variable-size integers encoding. (#24, @samoht)
 - Require `short_hash` operations to be explicitly unstaged. (#15, @CraigFe)
 - Require `equal` and `compare` operations to be explicitly unstaged. (#16, @samoht)
 

--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
  (name repr)
  (depends
   (ocaml (>= 4.08.0))
-  (fmt (>= 0.8.0))
+  (fmt (>= 0.8.7))
   uutf
   (jsonm (>= 1.0.0))
   (base64 (>= 2.0.0)))
@@ -58,4 +58,3 @@ guarantee.
   (ppxlib (and (>= 0.12.0) (< 0.18.0))))
  (synopsis "Fuzz tests for the `repr` package")
  (description "Fuzz tests for the `repr` package"))
-  

--- a/repr.opam
+++ b/repr.opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "fmt" {>= "0.8.0"}
+  "fmt" {>= "0.8.7"}
   "uutf"
   "jsonm" {>= "1.0.0"}
   "base64" {>= "2.0.0"}


### PR DESCRIPTION
As `Fmt.Dump.string` in only available in `fmt>=0.8.7`