### PR TITLE
ppx_repr: use Ast_pattern to avoid clashing with recent Ppxlib versions

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -2,9 +2,9 @@
  (name main)
  (public_name repr-bench)
  (package repr-bench)
- (libraries repr bechamel fpath yojson ppx_deriving_yojson.runtime unix)
+ (libraries repr bechamel fpath yojson unix)
  (preprocess
-  (pps ppx_repr ppx_deriving_yojson)))
+  (pps ppx_repr)))
 
 (rule
  (alias bench)

--- a/bench/output.ml
+++ b/bench/output.ml
@@ -19,13 +19,22 @@ type measurements = (metric * float) list
 let measurements_to_yojson ms =
   `Assoc (ms |> List.map (fun (m, v) -> (metric_to_string m, `Float v)))
 
-type output = { results : bench_result list }
-
-and bench_result = {
+type bench_result = {
   bench_name : string; [@key "name"]
   measurements : measurements; [@key "metrics"]
 }
-[@@deriving to_yojson]
+
+type output = { results : bench_result list }
+
+let bench_result_to_yojson { bench_name; measurements } =
+  `Assoc
+    [
+      ("bench_name", `String bench_name);
+      ("measurements", measurements_to_yojson measurements);
+    ]
+
+let output_to_yojson { results } =
+  `Assoc [ ("results", `List (List.map bench_result_to_yojson results)) ]
 
 (** Lift a binary function to operate over a larger type using an inner
     projection. *)

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@ guarantee.
  (name ppx_repr)
  (depends
   (repr (= :version))
-  (ppxlib (and (>= 0.12.0) (< 0.18.0)))
+  (ppxlib (>= 0.12.0))
   ; Test dependencies inherited from [repr] (see [test/repr/dune])
   (hex :with-test)
   (alcotest (and (>= 1.1.0) :with-test)))

--- a/dune-project
+++ b/dune-project
@@ -45,8 +45,7 @@ guarantee.
   (ppx_repr (= :version))
   bechamel
   yojson
-  fpath
-  ppx_deriving_yojson)
+  fpath)
  (synopsis "Benchmarks for the `repr` package")
  (description "Benchmarks for the `repr` package"))
 

--- a/dune-project
+++ b/dune-project
@@ -54,6 +54,6 @@ guarantee.
  (depends
   (repr (= :version))
   (crowbar (= 0.2))
-  (ppxlib (and (>= 0.12.0) (< 0.18.0))))
+  (ppxlib (and (>= 0.12.0))))
  (synopsis "Fuzz tests for the `repr` package")
  (description "Fuzz tests for the `repr` package"))

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
-  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "ppxlib" {>= "0.12.0"}
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}

--- a/repr-bench.opam
+++ b/repr-bench.opam
@@ -14,7 +14,6 @@ depends: [
   "bechamel"
   "yojson"
   "fpath"
-  "ppx_deriving_yojson"
   "odoc" {with-doc}
 ]
 build: [

--- a/repr-fuzz.opam
+++ b/repr-fuzz.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
   "crowbar" {= "0.2"}
-  "ppxlib" {>= "0.12.0" & < "0.18.0"}
+  "ppxlib" {>= "0.12.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Alternative to https://github.com/mirage/repr/pull/14 that should avoid needing to pick between pre-0.18 Ppxlib and more recent versions.