### PR TITLE
ppx_repr: add missing dependency on ppx_deriving

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,6 +32,7 @@ guarantee.
  (depends
   (repr (= :version))
   (ppxlib (>= 0.12.0))
+  ppx_deriving
   ; Test dependencies inherited from [repr] (see [test/repr/dune])
   (hex :with-test)
   (alcotest (and (>= 1.1.0) :with-test)))

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "repr" {= version}
   "ppxlib" {>= "0.12.0"}
+  "ppx_deriving"
   "hex" {with-test}
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
The `ppx_repr` library is flagged with `(kind ppx_deriver)`, which apparently causes Dune to add a dependency on `ppx_deriving` that was not reflected in the opam file. This isn't a problem when a `ppx_repr` dependency is built by Dune itself, but [can cause issues](https://github.com/roburio/dns-primary-git/pull/2#issuecomment-761779645) otherwise.

See https://github.com/ocaml/dune/issues/1327 for information about `(kind ppx_<>)`.