### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 0.2.1 (2020-01-18)
+
+- Support Ppxlib versions >= 0.18.0. (#35, @CraigFe)
+- Add missing dependency on `ppx_deriving`. (#36, CraigFe)
+- Add a representation of the `Either.t` type. (#33, @CraigFe)
+
 ### 0.2.0 (2020-12-18)
 
 - Improve performance of variable-size integers encoding and decoding.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### 0.2.1 (2020-01-18)
 
 - Support Ppxlib versions >= 0.18.0. (#35, @CraigFe)
-- Add missing dependency on `ppx_deriving`. (#36, CraigFe)
+- Add missing dependency on `ppx_deriving`. (#36, @CraigFe)
 - Add a representation of the `Either.t` type. (#33, @CraigFe)
 
 ### 0.2.0 (2020-12-18)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OCaml types and operations that are generic over those representations (`pp`,
 This library is currently experimental and provides no stability guarantee. The
 documentation is available [online][docs].
 
-[docs]: https://docs.mirage.io/repr/Repr/index.html
+[docs]: https://mirage.github.io/repr/repr/index.html
 
 ### Installation
 


### PR DESCRIPTION
Now with OCaml 4.12 support.

Corresponding `opam-repository` PR: https://github.com/ocaml/opam-repository/pull/17992.