### PR TITLE
ppx_repr: initial support for mutually-recursive types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
   to e.g. `Bool.t` or `Stdlib.Int32.t` will be resolved to the corresponding
   combinators. (#43, @CraigFe)
 
+- Add support for deriving mutually-recursive pairs of type representations
+  with `ppx_repr`. (#42, @CraigFe)
+
 ### 0.2.1 (2021-01-18)
 
 - Support Ppxlib versions >= 0.18.0. (#35, @CraigFe)

--- a/src/ppx_repr/lib/utils.ml
+++ b/src/ppx_repr/lib/utils.ml
@@ -9,6 +9,26 @@ module Option = struct
   let to_bool : unit option -> bool = function Some () -> true | None -> false
 end
 
+module List = struct
+  include List
+
+  let reduce ~f = function
+    | [] -> None
+    | [ x ] -> Some x
+    | _ :: _ :: _ as l ->
+        let rec aux = function
+          | [] -> assert false
+          | [ a; b ] -> f a b
+          | x :: xs -> f x (aux xs)
+        in
+        Some (aux l)
+
+  let reduce_exn ~f l =
+    match reduce ~f l with
+    | Some x -> x
+    | None -> failwith "Cannot reduce empty list"
+end
+
 module Make (A : Ast_builder.S) : sig
   val compose_all : ('a -> 'a) list -> 'a -> 'a
   (** Left-to-right composition of a list of functions. *)

--- a/test/ppx_repr/deriver/errors/dune.inc
+++ b/test/ppx_repr/deriver/errors/dune.inc
@@ -50,6 +50,53 @@
  (action
   (diff nobuiltin_nonempty.expected nobuiltin_nonempty.actual)))
 
+; -------- Test: `recursion_more_than_two.ml` --------
+
+
+
+; Run the PPX on the `.ml` file
+(rule
+ (targets recursion_more_than_two.actual)
+ (deps
+  (:pp pp.exe)
+  (:input recursion_more_than_two.ml))
+ (action
+  ; expect the process to fail, capturing stderr
+  (with-stderr-to
+   %{targets}
+   (bash "! ./%{pp} -no-color --impl %{input}"))))
+
+; Compare the post-processed output to the .expected file
+(rule
+ (alias runtest)
+ (package ppx_repr)
+ (action
+  (diff recursion_more_than_two.expected recursion_more_than_two.actual)))
+
+; -------- Test: `recursion_with_type_parameters.ml` --------
+
+
+
+; Run the PPX on the `.ml` file
+(rule
+ (targets recursion_with_type_parameters.actual)
+ (deps
+  (:pp pp.exe)
+  (:input recursion_with_type_parameters.ml))
+ (action
+  ; expect the process to fail, capturing stderr
+  (with-stderr-to
+   %{targets}
+   (bash "! ./%{pp} -no-color --impl %{input}"))))
+
+; Compare the post-processed output to the .expected file
+(rule
+ (alias runtest)
+ (package ppx_repr)
+ (action
+  (diff recursion_with_type_parameters.expected
+    recursion_with_type_parameters.actual)))
+
 ; -------- Test: `unsupported_tuple_size.ml` --------
 
 

--- a/test/ppx_repr/deriver/errors/recursion_more_than_two.expected
+++ b/test/ppx_repr/deriver/errors/recursion_more_than_two.expected
@@ -1,0 +1,1 @@
+Fatal error: exception (Failure "Mutually-recursive groups of size > 2 supported")

--- a/test/ppx_repr/deriver/errors/recursion_more_than_two.ml
+++ b/test/ppx_repr/deriver/errors/recursion_more_than_two.ml
@@ -1,0 +1,5 @@
+type t1 = t2 option
+
+and t2 = t3 option
+
+and t3 = t1 option [@@deriving repr]

--- a/test/ppx_repr/deriver/errors/recursion_with_type_parameters.expected
+++ b/test/ppx_repr/deriver/errors/recursion_with_type_parameters.expected
@@ -1,0 +1,1 @@
+Fatal error: exception (Failure "Can't support mutually-recursive types with type parameters")

--- a/test/ppx_repr/deriver/errors/recursion_with_type_parameters.ml
+++ b/test/ppx_repr/deriver/errors/recursion_with_type_parameters.ml
@@ -1,0 +1,3 @@
+type 'a t1 = 'a * t2 option
+
+and t2 = int * unit t1 option [@@deriving repr]

--- a/test/ppx_repr/deriver/passing/dune.inc
+++ b/test/ppx_repr/deriver/passing/dune.inc
@@ -414,6 +414,38 @@
  (action
   (run ./record.exe)))
 
+; -------- Test: `recursive.ml` --------
+
+; The PPX-dependent executable under test
+(executable
+ (name recursive)
+ (modules recursive)
+ (preprocess (pps ppx_repr))
+ (libraries repr))
+
+; Run the PPX on the `.ml` file
+(rule
+ (targets recursive.actual)
+ (deps
+  (:pp pp.exe)
+  (:input recursive.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+; Compare the post-processed output to the .expected file
+(rule
+ (alias runtest)
+ (package ppx_repr)
+ (action
+  (diff recursive.expected recursive.actual)))
+
+; Ensure that the post-processed executable runs correctly
+(rule
+ (alias runtest)
+ (package ppx_repr)
+ (action
+  (run ./recursive.exe)))
+
 ; -------- Test: `signature.ml` --------
 
 ; The PPX-dependent executable under test

--- a/test/ppx_repr/deriver/passing/recursive.expected
+++ b/test/ppx_repr/deriver/passing/recursive.expected
@@ -1,0 +1,51 @@
+module Non_recursive_group :
+  sig
+    type nonrec t0
+    and t1
+    and t2[@@deriving repr]
+    include
+      sig val t0_t : t0 Repr.t val t1_t : t1 Repr.t val t2_t : t2 Repr.t end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
+  end =
+  struct
+    type nonrec t0 = unit
+    and t1 = unit
+    and t2 = unit[@@deriving repr]
+    include
+      struct
+        let (t0_t, (t1_t, t2_t)) = (Repr.unit, (Repr.unit, Repr.unit))
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end 
+module Recursive_group :
+  sig
+    type even
+    and odd[@@deriving repr]
+    include sig val even_t : even Repr.t val odd_t : odd Repr.t end[@@ocaml.doc
+                                                                    "@inline"]
+    [@@merlin.hide ]
+  end =
+  struct
+    type odd =
+      | Odd of even option 
+    and even =
+      | Even of odd option [@@deriving repr]
+    include
+      struct
+        let (odd_t, even_t) =
+          Repr.mu2
+            (fun odd_t ->
+               fun even_t ->
+                 ((Repr.sealv
+                     (Repr.(|~)
+                        (Repr.variant "odd"
+                           (fun odd -> function | Odd x1 -> odd x1))
+                        (Repr.case1 "Odd" (Repr.option even_t)
+                           (fun x1 -> Odd x1)))),
+                   (Repr.sealv
+                      (Repr.(|~)
+                         (Repr.variant "even"
+                            (fun even -> function | Even x1 -> even x1))
+                         (Repr.case1 "Even" (Repr.option odd_t)
+                            (fun x1 -> Even x1))))))
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end 

--- a/test/ppx_repr/deriver/passing/recursive.ml
+++ b/test/ppx_repr/deriver/passing/recursive.ml
@@ -1,0 +1,25 @@
+(* Non-recursive group of type declarations: *)
+
+module Non_recursive_group : sig
+  type nonrec t0
+
+  and t1
+
+  and t2 [@@deriving repr]
+end = struct
+  type nonrec t0 = unit
+
+  and t1 = unit
+
+  and t2 = unit [@@deriving repr]
+end
+
+module Recursive_group : sig
+  type even
+
+  and odd [@@deriving repr]
+end = struct
+  type odd = Odd of even option
+
+  and even = Even of odd option [@@deriving repr]
+end


### PR DESCRIPTION
Resolves https://github.com/mirage/repr/issues/6.

Implementation is relatively simple. I was surprised at the caveats we require w.r.t. mutually-recursive types, but these come from `repr` itself. In particular:
 - can't have mutually-recursive groups of size >= 3;
 - can't have mutually-recursive groups where any type has a type parameter.