### PR TITLE
Add combinators for Stdlib container types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,11 @@
 
 - Add combinators for standard library container types: `ref`, `Lazy.t`,
   `Seq.t`, `Queue.t`, `Stack.t`, `Hashtbl.t`, `Set.t` and `Map.t`.
-  (#TODO, @CraigFe)
+  (#43, @CraigFe)
+
+- Improve PPX `Repr.t` generation for types in the standard library. References
+  to e.g. `Bool.t` or `Stdlib.Int32.t` will be resolved to the corresponding
+  combinators. (#43, @CraigFe)
 
 ### 0.2.1 (2021-01-18)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+- Add combinators for standard library container types: `ref`, `Lazy.t`,
+  `Seq.t`, `Queue.t`, `Stack.t`, `Hashtbl.t`, `Set.t` and `Map.t`.
+  (#TODO, @CraigFe)
+
 ### 0.2.1 (2021-01-18)
 
 - Support Ppxlib versions >= 0.18.0. (#35, @CraigFe)

--- a/src/ppx_repr/lib/dsl.ml
+++ b/src/ppx_repr/lib/dsl.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (c) 2019-2020 Craig Ferguson <me@craigfe.io>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Ppxlib
+
+(** This module defines the expected combinators exposed by Repr, and their
+    correspondences to the types in the standard library. *)
+
+let rec drop_stdlib_prefix = function
+  | (Lident _ | Lapply _) as l -> l
+  | Ldot (Lident "Stdlib", suffix) -> Lident suffix
+  | Ldot (l, suffix) -> Ldot (drop_stdlib_prefix l, suffix)
+
+let basic =
+  [
+    "unit";
+    "bool";
+    "char";
+    "int";
+    "int32";
+    "int64";
+    "float";
+    "string";
+    "bytes";
+    "list";
+    "array";
+    "option";
+    "result";
+  ]
+
+let containers = [ "either"; "hashtbl"; "queue"; "seq"; "stack" ]
+let type_in_default_scope name = (Lident name, name)
+
+let type_in_separate_module name =
+  (Ldot (Lident (String.capitalize_ascii name), "t"), name)
+
+let type_to_combinator_name : longident -> string option =
+  let correspondences =
+    let assoc =
+      (* Abstract types with equivalent combinator names: *)
+      List.map type_in_default_scope basic
+      (* Types named [t] within their own modules: *)
+      @ List.map type_in_separate_module (basic @ containers)
+      (* Technically [lazy_t] is not for direct use, but derive anyway *)
+      @ [ (Lident "lazy_t", "lazy_t"); (Ldot (Lident "Lazy", "t"), "lazy_t") ]
+    in
+    List.to_seq assoc |> Hashtbl.of_seq
+  in
+  fun lident -> Hashtbl.find_opt correspondences (drop_stdlib_prefix lident)

--- a/src/ppx_repr/lib/utils.ml
+++ b/src/ppx_repr/lib/utils.ml
@@ -3,6 +3,12 @@ open Ppxlib
 let ( >> ) f g x = g (f x)
 let ( >|= ) x f = List.map f x
 
+module Option = struct
+  include Option
+
+  let to_bool : unit option -> bool = function Some () -> true | None -> false
+end
+
 module Make (A : Ast_builder.S) : sig
   val compose_all : ('a -> 'a) list -> 'a -> 'a
   (** Left-to-right composition of a list of functions. *)

--- a/src/repr/type.ml
+++ b/src/repr/type.ml
@@ -398,7 +398,13 @@ let seq : type a. a t -> a Seq.t t =
     List.of_seq
 
 let stack : type a. a t -> a Stack.t t =
- fun a -> map (seq a) Stack.of_seq Stack.to_seq
+  (* Built-in [Stack.of_seq] adds elements bottom-to-top, which flips the stack. We must re-flip it afterwards. *)
+  let flip_stack s_rev =
+    let s = Stack.create () in
+    Stack.iter (fun a -> Stack.push a s) s_rev;
+    s
+  in
+  fun a -> map (seq a) (fun s -> Stack.of_seq s |> flip_stack) Stack.to_seq
 
 let queue : type a. a t -> a Queue.t t =
  fun a -> map (seq a) Queue.of_seq Queue.to_seq

--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -579,6 +579,9 @@ module type DSL = sig
     ('b -> 'a) ->
     ('a -> 'b) ->
     'a t
+  (** This combinator allows defining a representative of one type in terms of
+      another by supplying coercions between them. For a representative of
+      [Stdlib.Map], see {!Of_map}. *)
 
   type 'a ty = 'a t
 

--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -72,6 +72,60 @@ module type DSL = sig
   val either : 'a t -> 'b t -> ('a, 'b) Either.t t
   (** [either a b] is a representation of values of type [(a, b) Either.t]. *)
 
+  val seq : 'a t -> 'a Seq.t t
+  (** [seq t] is a representation of sequences of values of type [t]. *)
+
+  val ref : 'a t -> 'a ref t
+  (** [ref t] is a representation of references to values of type [t].
+
+      {b Note}: derived deserialisation functions will not preserve reference
+      sharing. *)
+
+  val lazy_t : 'a t -> 'a Lazy.t t
+  (** [lazy_t t] is a representation of lazy values of type [t].
+
+      {b Note}: derived deserialisation functions on the resulting type will not
+      be lazy. *)
+
+  val queue : 'a t -> 'a Queue.t t
+  (** [queue t] is a representation of queues of values of type [t]. *)
+
+  val stack : 'a t -> 'a Stack.t t
+  (** [stack t] is a representation of stacks of values of type [t]. *)
+
+  val hashtbl : 'k t -> 'v t -> ('k, 'v) Hashtbl.t t
+  (** [hashtbl k v] is a representation of hashtables with keys of type [k] and
+      values of type [v]. *)
+
+  val set :
+    (module Set.S with type elt = 'elt and type t = 'set) -> 'elt t -> 'set t
+  (** [set (module Set) elt] is a representation of sets with elements of type
+      [elt]. See {!Of_set} for a functorised equivalent of this function. *)
+
+  (** Functor for building representatives of {i sets} from the standard
+      library. *)
+  module Of_set (Set : sig
+    type elt
+
+    val elt_t : elt t
+
+    include Set.S with type elt := elt
+  end) : sig
+    val t : Set.t t
+  end
+
+  (** Functor for building representatives of {i maps} from the standard
+      library. *)
+  module Of_map (Map : sig
+    type key
+
+    val key_t : key t
+
+    include Map.S with type key := key
+  end) : sig
+    val t : 'v t -> 'v Map.t t
+  end
+
   (** An uninhabited type, defined as a variant with no constructors. *)
   type empty = |
 

--- a/test/ppx_repr/deriver/passing/basic.expected
+++ b/test/ppx_repr/deriver/passing/basic.expected
@@ -1,21 +1,163 @@
-type test_unit = unit[@@deriving repr]
-include struct let test_unit_t = Repr.unit end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_bool = bool[@@deriving repr]
-include struct let test_bool_t = Repr.bool end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_char = char[@@deriving repr]
-include struct let test_char_t = Repr.char end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_int32 = int32[@@deriving repr]
-include struct let test_int32_t = Repr.int32 end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_int64 = int64[@@deriving repr]
-include struct let test_int64_t = Repr.int64 end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_float = float[@@deriving repr]
-include struct let test_float_t = Repr.float end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
-type test_string = string[@@deriving repr]
-include struct let test_string_t = Repr.string end[@@ocaml.doc "@inline"]
-[@@merlin.hide ]
+module type BASIC  =
+  sig
+    val test_unit_t : unit Repr.t
+    val test_bool_t : bool Repr.t
+    val test_char_t : char Repr.t
+    val test_int_t : int Repr.t
+    val test_int32_t : int32 Repr.t
+    val test_int64_t : int64 Repr.t
+    val test_float_t : float Repr.t
+    val test_string_t : string Repr.t
+    val test_bytes_t : bytes Repr.t
+  end
+module Basic : BASIC =
+  struct
+    type test_unit = unit[@@deriving repr]
+    include struct let test_unit_t = Repr.unit end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_bool = bool[@@deriving repr]
+    include struct let test_bool_t = Repr.bool end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_char = char[@@deriving repr]
+    include struct let test_char_t = Repr.char end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int = int[@@deriving repr]
+    include struct let test_int_t = Repr.int end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int32 = int32[@@deriving repr]
+    include struct let test_int32_t = Repr.int32 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int64 = int64[@@deriving repr]
+    include struct let test_int64_t = Repr.int64 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_float = float[@@deriving repr]
+    include struct let test_float_t = Repr.float end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_string = string[@@deriving repr]
+    include struct let test_string_t = Repr.string end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_bytes = bytes[@@deriving repr]
+    include struct let test_bytes_t = Repr.bytes end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+  end 
+module Composite : sig  end =
+  struct
+    type test_list1 = string list[@@deriving repr]
+    include struct let test_list1_t = Repr.list Repr.string end[@@ocaml.doc
+                                                                 "@inline"]
+    [@@merlin.hide ]
+    type test_list2 = int32 list list list[@@deriving repr]
+    include
+      struct
+        let test_list2_t = Repr.list (Repr.list (Repr.list Repr.int32))
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type test_array = bool array[@@deriving repr]
+    include struct let test_array_t = Repr.array Repr.bool end[@@ocaml.doc
+                                                                "@inline"]
+    [@@merlin.hide ]
+    type test_option = unit option[@@deriving repr]
+    include struct let test_option_t = Repr.option Repr.unit end[@@ocaml.doc
+                                                                  "@inline"]
+    [@@merlin.hide ]
+    type test_pair = (string * int32)[@@deriving repr]
+    include struct let test_pair_t = Repr.pair Repr.string Repr.int32 end
+    [@@ocaml.doc "@inline"][@@merlin.hide ]
+    type test_triple = (string * int32 * bool)[@@deriving repr]
+    include
+      struct
+        let test_triple_t = Repr.triple Repr.string Repr.int32 Repr.bool
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type test_result = (int32 lazy_t, string) result[@@deriving repr]
+    include
+      struct
+        let test_result_t = Repr.result (Repr.lazy_t Repr.int32) Repr.string
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    let (_ : test_list1 Repr.t) = test_list1_t
+    let (_ : test_list2 Repr.t) = test_list2_t
+    let (_ : test_array Repr.t) = test_array_t
+    let (_ : test_option Repr.t) = test_option_t
+    let (_ : test_pair Repr.t) = test_pair_t
+    let (_ : test_triple Repr.t) = test_triple_t
+    let (_ : test_result Repr.t) = test_result_t
+  end 
+module Inside_modules :
+  sig
+    include BASIC
+    val test_list_t : 'a Repr.t -> 'a List.t Repr.t
+    val test_array_t : 'a Repr.t -> 'a Array.t Repr.t
+    val test_option_t : 'a Repr.t -> 'a Option.t Repr.t
+    val test_lazy_t : 'a Repr.t -> 'a Lazy.t Repr.t
+    val test_result_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Result.t Repr.t
+    val test_seq_t : 'a Repr.t -> 'a Seq.t Repr.t
+    val test_hashtbl_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Hashtbl.t Repr.t
+    val test_stack_t : 'a Repr.t -> 'a Stack.t Repr.t
+    val test_queue_t : 'a Repr.t -> 'a Queue.t Repr.t
+    val test_either_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Either.t Repr.t
+  end =
+  struct
+    type test_unit = Unit.t[@@deriving repr]
+    include struct let test_unit_t = Repr.unit end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_bool = Bool.t[@@deriving repr]
+    include struct let test_bool_t = Repr.bool end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_char = Char.t[@@deriving repr]
+    include struct let test_char_t = Repr.char end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int = Int.t[@@deriving repr]
+    include struct let test_int_t = Repr.int end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int32 = Int32.t[@@deriving repr]
+    include struct let test_int32_t = Repr.int32 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int64 = Int64.t[@@deriving repr]
+    include struct let test_int64_t = Repr.int64 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_float = Float.t[@@deriving repr]
+    include struct let test_float_t = Repr.float end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_string = String.t[@@deriving repr]
+    include struct let test_string_t = Repr.string end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_bytes = Bytes.t[@@deriving repr]
+    include struct let test_bytes_t = Repr.bytes end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type 'a test_list = 'a List.t[@@deriving repr]
+    include struct let test_list_t a = Repr.list a end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type 'a test_array = 'a Array.t[@@deriving repr]
+    include struct let test_array_t a = Repr.array a end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
+    type 'a test_option = 'a Option.t[@@deriving repr]
+    include struct let test_option_t a = Repr.option a end[@@ocaml.doc
+                                                            "@inline"]
+    [@@merlin.hide ]
+    type 'a test_lazy = 'a Lazy.t[@@deriving repr]
+    include struct let test_lazy_t a = Repr.lazy_t a end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
+    type ('a, 'b) test_result = ('a, 'b) Result.t[@@deriving repr]
+    include struct let test_result_t a b = Repr.result a b end[@@ocaml.doc
+                                                                "@inline"]
+    [@@merlin.hide ]
+    type 'a test_seq = 'a Seq.t[@@deriving repr]
+    include struct let test_seq_t a = Repr.seq a end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type ('a, 'b) test_hashtbl = ('a, 'b) Hashtbl.t[@@deriving repr]
+    include struct let test_hashtbl_t a b = Repr.hashtbl a b end[@@ocaml.doc
+                                                                  "@inline"]
+    [@@merlin.hide ]
+    type 'a test_stack = 'a Stack.t[@@deriving repr]
+    include struct let test_stack_t a = Repr.stack a end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
+    type 'a test_queue = 'a Queue.t[@@deriving repr]
+    include struct let test_queue_t a = Repr.queue a end[@@ocaml.doc
+                                                          "@inline"][@@merlin.hide
+                                                                    ]
+    type ('a, 'b) test_either = ('a, 'b) Either.t[@@deriving repr]
+    include struct let test_either_t a b = Repr.either a b end[@@ocaml.doc
+                                                                "@inline"]
+    [@@merlin.hide ]
+  end 

--- a/test/ppx_repr/deriver/passing/basic.ml
+++ b/test/ppx_repr/deriver/passing/basic.ml
@@ -1,8 +1,79 @@
-(* Tests of the basic types *)
-type test_unit = unit [@@deriving repr]
-type test_bool = bool [@@deriving repr]
-type test_char = char [@@deriving repr]
-type test_int32 = int32 [@@deriving repr]
-type test_int64 = int64 [@@deriving repr]
-type test_float = float [@@deriving repr]
-type test_string = string [@@deriving repr]
+module type BASIC = sig
+  val test_unit_t : unit Repr.t
+  val test_bool_t : bool Repr.t
+  val test_char_t : char Repr.t
+  val test_int_t : int Repr.t
+  val test_int32_t : int32 Repr.t
+  val test_int64_t : int64 Repr.t
+  val test_float_t : float Repr.t
+  val test_string_t : string Repr.t
+  val test_bytes_t : bytes Repr.t
+end
+
+module Basic : BASIC = struct
+  type test_unit = unit [@@deriving repr]
+  type test_bool = bool [@@deriving repr]
+  type test_char = char [@@deriving repr]
+  type test_int = int [@@deriving repr]
+  type test_int32 = int32 [@@deriving repr]
+  type test_int64 = int64 [@@deriving repr]
+  type test_float = float [@@deriving repr]
+  type test_string = string [@@deriving repr]
+  type test_bytes = bytes [@@deriving repr]
+end
+
+module Composite : sig end = struct
+  type test_list1 = string list [@@deriving repr]
+  type test_list2 = int32 list list list [@@deriving repr]
+  type test_array = bool array [@@deriving repr]
+  type test_option = unit option [@@deriving repr]
+  type test_pair = string * int32 [@@deriving repr]
+  type test_triple = string * int32 * bool [@@deriving repr]
+  type test_result = (int32 lazy_t, string) result [@@deriving repr]
+
+  let (_ : test_list1 Repr.t) = test_list1_t
+  let (_ : test_list2 Repr.t) = test_list2_t
+  let (_ : test_array Repr.t) = test_array_t
+  let (_ : test_option Repr.t) = test_option_t
+  let (_ : test_pair Repr.t) = test_pair_t
+  let (_ : test_triple Repr.t) = test_triple_t
+  let (_ : test_result Repr.t) = test_result_t
+end
+
+module Inside_modules : sig
+  include BASIC
+
+  (* Aliases of composite types *)
+  val test_list_t : 'a Repr.t -> 'a List.t Repr.t
+  val test_array_t : 'a Repr.t -> 'a Array.t Repr.t
+  val test_option_t : 'a Repr.t -> 'a Option.t Repr.t
+  val test_lazy_t : 'a Repr.t -> 'a Lazy.t Repr.t
+  val test_result_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Result.t Repr.t
+
+  (* Other container types *)
+  val test_seq_t : 'a Repr.t -> 'a Seq.t Repr.t
+  val test_hashtbl_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Hashtbl.t Repr.t
+  val test_stack_t : 'a Repr.t -> 'a Stack.t Repr.t
+  val test_queue_t : 'a Repr.t -> 'a Queue.t Repr.t
+  val test_either_t : 'a Repr.t -> 'b Repr.t -> ('a, 'b) Either.t Repr.t
+end = struct
+  type test_unit = Unit.t [@@deriving repr]
+  type test_bool = Bool.t [@@deriving repr]
+  type test_char = Char.t [@@deriving repr]
+  type test_int = Int.t [@@deriving repr]
+  type test_int32 = Int32.t [@@deriving repr]
+  type test_int64 = Int64.t [@@deriving repr]
+  type test_float = Float.t [@@deriving repr]
+  type test_string = String.t [@@deriving repr]
+  type test_bytes = Bytes.t [@@deriving repr]
+  type 'a test_list = 'a List.t [@@deriving repr]
+  type 'a test_array = 'a Array.t [@@deriving repr]
+  type 'a test_option = 'a Option.t [@@deriving repr]
+  type 'a test_lazy = 'a Lazy.t [@@deriving repr]
+  type ('a, 'b) test_result = ('a, 'b) Result.t [@@deriving repr]
+  type 'a test_seq = 'a Seq.t [@@deriving repr]
+  type ('a, 'b) test_hashtbl = ('a, 'b) Hashtbl.t [@@deriving repr]
+  type 'a test_stack = 'a Stack.t [@@deriving repr]
+  type 'a test_queue = 'a Queue.t [@@deriving repr]
+  type ('a, 'b) test_either = ('a, 'b) Either.t [@@deriving repr]
+end


### PR DESCRIPTION
Add the following combinators:

```ocaml
val seq : 'a t -> 'a Seq.t t
val ref : 'a t -> 'a ref t
val lazy_t : 'a t -> 'a Lazy.t t
val queue : 'a t -> 'a Queue.t t
val stack : 'a t -> 'a Stack.t t
val hashtbl : 'k t -> 'v t -> ('k, 'v) Hashtbl.t t

module Of_set (Set) : sig val t : Set.t t end
module Of_map (Map) : sig val t : 'v t -> 'v Map.t t end
```

The implementations of these are fairly bare-bones: mostly just using conversions to `list`. These could probably be improved on a second pass.

Resolves https://github.com/mirage/repr/issues/25.