### PR TITLE
Add make target and print only json result to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: bench
+
+bench:
+	@dune exec -- bench/main.exe

--- a/bench/output.ml
+++ b/bench/output.ml
@@ -29,8 +29,8 @@ type output = { results : bench_result list }
 let bench_result_to_yojson { bench_name; measurements } =
   `Assoc
     [
-      ("bench_name", `String bench_name);
-      ("measurements", measurements_to_yojson measurements);
+      ("name", `String bench_name);
+      ("metrics", measurements_to_yojson measurements);
     ]
 
 let output_to_yojson { results } =


### PR DESCRIPTION
~We need to print only json to the stdout for CB pipeline, hence masking the printf's under the json flag.~ Ocurrent `pread` only cares about stdout, pipeline needs specific key names, so correcting that.