### PR TITLE
Conflict with ocaml-migrate-parsetree.1.7.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.16.0
+version = 0.17.0
 profile = conventional
 parse-docstrings
 break-infix = fit-or-vertical

--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,9 @@ guarantee.
   ; Test dependencies inherited from [repr] (see [test/repr/dune])
   (hex :with-test)
   (alcotest (and (>= 1.1.0) :with-test)))
+ ;; See https://github.com/mirage/repr/issues/48
+ ;; Can be removed once using Ppxlib >= 0.16.0
+ (conflicts (ocaml-migrate-parsetree (= 1.7.1)))
  (synopsis "PPX deriver for type representations")
  (description "PPX deriver for type representations"))
 

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -16,6 +16,9 @@ depends: [
   "alcotest" {>= "1.1.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
This release accidentally exposed a top-level `Option` module. See
https://github.com/mirage/repr/issues/48.