### PR TITLE
Remove unused [@@deriving branded] annotation

### DIFF
--- a/src/repr/type_binary.ml
+++ b/src/repr/type_binary.ml
@@ -324,7 +324,7 @@ module Decode = struct
             (ofs, Some x))
 
   module Record_decoder = Fields_folder (struct
-    type ('a, 'b) t = string -> int -> 'b -> 'a res [@@deriving branded]
+    type ('a, 'b) t = string -> int -> 'b -> 'a res
   end)
 
   let rec t : type a. a t -> a decode_bin = function


### PR DESCRIPTION
Spotted by @ngoguey. Shame that we don't get Ppxlib errors when not linking against Ppxlib...