### PR TITLE
Drop (strict_package_deps)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,6 @@
 (lang dune 2.7)
 (generate_opam_files true)
 (allow_approximate_merlin)
-(strict_package_deps)
 
 (name repr)
 (source (github mirage/repr))


### PR DESCRIPTION
This stanza makes Repr incompatible with using vendoring for package management, since the (transitive) vendored dependencies aren't specified in the `dune-project` file.