### PR TITLE
Reorganise JSON codec API

### DIFF
--- a/src/repr/type.ml
+++ b/src/repr/type.ml
@@ -62,7 +62,7 @@ let boxed t = Boxed t
 
 let v ~pp ~of_string ~json ~bin ?unboxed_bin ~equal ~compare ~short_hash
     ~pre_hash () =
-  let encode_json, decode_json = json in
+  let encode_jsonm, decode_json = json in
   let encode_bin, decode_bin, size_of = bin in
   let unboxed_encode_bin, unboxed_decode_bin, unboxed_size_of =
     match unboxed_bin with None -> bin | Some b -> b
@@ -73,7 +73,7 @@ let v ~pp ~of_string ~json ~bin ?unboxed_bin ~equal ~compare ~short_hash
       pp;
       of_string;
       pre_hash;
-      encode_json;
+      encode_jsonm;
       decode_json;
       encode_bin;
       decode_bin;
@@ -264,7 +264,7 @@ let like ?pp ?of_string ?json ?bin ?unboxed_bin ?equal ?compare ?short_hash:h
     | Some x -> x
     | None -> generic_op t
   in
-  let encode_json, decode_json =
+  let encode_jsonm, decode_json =
     let ( >|= ) l f = match l with Ok l -> Ok (f l) | Error _ as e -> e in
     let join = function Error _ as e -> e | Ok x -> x in
     match json with
@@ -316,7 +316,7 @@ let like ?pp ?of_string ?json ?bin ?unboxed_bin ?equal ?compare ?short_hash:h
       cwit = `Type t;
       pp;
       of_string;
-      encode_json;
+      encode_jsonm;
       decode_json;
       encode_bin;
       decode_bin;
@@ -356,10 +356,12 @@ let pp, pp_dump, pp_ty, to_string, of_string =
 let ( to_json_string,
       of_json_string,
       pp_json,
-      encode_json,
+      encode_jsonm,
+      decode_jsonm,
       decode_json,
-      decode_json_lexemes ) =
-  Type_json.(to_string, of_string, pp, encode, decode_jsonm, decode_lexemes)
+      decode_jsonm_lexemes ) =
+  Type_json.
+    (to_string, of_string, pp, encode, decode_jsonm, decode, decode_lexemes)
 
 let encode_bin, decode_bin, to_bin_string, of_bin_string =
   Type_binary.(encode_bin, decode_bin, to_bin_string, of_bin_string)

--- a/src/repr/type_core.ml
+++ b/src/repr/type_core.ml
@@ -35,7 +35,7 @@ end
 
 let partial ?(pp = fun _ -> failwith "`pp` not implemented")
     ?(of_string = fun _ -> failwith "`of_string` not implemented")
-    ?(encode_json = fun _ -> failwith "`encode_json` not implemented")
+    ?(encode_jsonm = fun _ -> failwith "`encode_jsonm` not implemented")
     ?(decode_json = fun _ -> failwith "`decode_json` not implemented")
     ?(short_hash =
       stage (fun ?seed:_ _ -> failwith "`short_hash` not implemented"))
@@ -56,7 +56,7 @@ let partial ?(pp = fun _ -> failwith "`pp` not implemented")
       cwit = `Witness (Witness.make ());
       pp;
       of_string;
-      encode_json;
+      encode_jsonm;
       decode_json;
       short_hash;
       pre_hash;

--- a/src/repr/type_core_intf.ml
+++ b/src/repr/type_core_intf.ml
@@ -5,7 +5,7 @@ module Types = struct
   type 'a pp = 'a Fmt.t
   type 'a of_string = string -> ('a, [ `Msg of string ]) result
   type 'a to_string = 'a -> string
-  type 'a encode_json = Jsonm.encoder -> 'a -> unit
+  type 'a encode_jsonm = Jsonm.encoder -> 'a -> unit
   type json_decoder = { mutable lexemes : Jsonm.lexeme list; d : Jsonm.decoder }
   type 'a decode_json = json_decoder -> ('a, [ `Msg of string ]) result
   type 'a bin_seq = 'a -> (string -> unit) -> unit
@@ -37,7 +37,7 @@ module Types = struct
     cwit : [ `Type of 'a t | `Witness of 'a Witness.t ];
     pp : 'a pp;
     of_string : 'a of_string;
-    encode_json : 'a encode_json;
+    encode_jsonm : 'a encode_jsonm;
     decode_json : 'a decode_json;
     short_hash : 'a short_hash;
     pre_hash : 'a encode_bin;
@@ -153,7 +153,7 @@ module type Type_core = sig
   val partial :
     ?pp:'a pp ->
     ?of_string:'a of_string ->
-    ?encode_json:'a encode_json ->
+    ?encode_jsonm:'a encode_jsonm ->
     ?decode_json:'a decode_json ->
     ?short_hash:'a short_hash ->
     ?pre_hash:'a pre_hash ->

--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -427,7 +427,7 @@ module type DSL = sig
         such an assoc as a JSON object. *)
   end
 
-  type 'a encode_json = Jsonm.encoder -> 'a -> unit
+  type 'a encode_jsonm = Jsonm.encoder -> 'a -> unit
   (** The type for JSON encoders. *)
 
   type 'a decode_json = Json.decoder -> ('a, [ `Msg of string ]) result
@@ -435,7 +435,7 @@ module type DSL = sig
 
   val pp_json : ?minify:bool -> 'a t -> 'a Fmt.t
   (** Similar to {!dump} but pretty-prints the JSON representation instead of
-      the OCaml one. See {!encode_json} for details about the encoding.
+      the OCaml one. See {!encode_jsonm} for details about the encoding.
 
       For instance:
 
@@ -460,8 +460,8 @@ module type DSL = sig
       {b NOTE:} this will automatically convert JSON fragments to valid JSON
       objects by adding an enclosing array if necessary. *)
 
-  val encode_json : 'a t -> Jsonm.encoder -> 'a -> unit
-  (** [encode_json t e] encodes [t] into the
+  val encode_jsonm : 'a t -> Jsonm.encoder -> 'a -> unit
+  (** [encode_jsonm t e] encodes [t] into the
       {{:http://erratique.ch/software/jsonm} jsonm} encoder [e]. The encoding is
       a relatively straightforward translation of the OCaml structure into JSON.
       The main highlights are:
@@ -483,17 +483,20 @@ module type DSL = sig
       responsibility of the caller to ensure that the encoded JSON fragment fits
       properly into a well-formed JSON object. *)
 
-  val decode_json : 'a t -> Jsonm.decoder -> ('a, [ `Msg of string ]) result
-  (** [decode_json t e] decodes values of type [t] from the
+  val decode_jsonm : 'a t -> Jsonm.decoder -> ('a, [ `Msg of string ]) result
+  (** [decode_jsonm t e] decodes values of type [t] from the
       {{:http://erratique.ch/software/jsonm} jsonm} decoder [e]. *)
 
-  val decode_json_lexemes :
+  val decode_jsonm_lexemes :
     'a t -> Jsonm.lexeme list -> ('a, [ `Msg of string ]) result
-  (** [decode_json_lexemes] is similar to {!decode_json} but uses an already
+  (** [decode_jsonm_lexemes] is similar to {!decode_jsonm} but uses an already
       decoded list of JSON lexemes instead of a decoder. *)
 
+  val decode_json : 'a t -> 'a decode_json
+  (** TODO *)
+
   val to_json_string : ?minify:bool -> 'a t -> 'a -> string
-  (** [to_json_string] is {!encode_json} with a string encoder. *)
+  (** [to_json_string] is {!encode_jsonm} with a string encoder. *)
 
   val of_json_string : 'a t -> string -> ('a, [ `Msg of string ]) result
   (** [of_json_string] is {!decode_json} with a string decoder .*)
@@ -576,7 +579,7 @@ module type DSL = sig
   val v :
     pp:'a pp ->
     of_string:'a of_string ->
-    json:'a encode_json * 'a decode_json ->
+    json:'a encode_jsonm * 'a decode_json ->
     bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     equal:'a equal ->
@@ -589,7 +592,7 @@ module type DSL = sig
   val like :
     ?pp:'a pp ->
     ?of_string:'a of_string ->
-    ?json:'a encode_json * 'a decode_json ->
+    ?json:'a encode_jsonm * 'a decode_json ->
     ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?equal:'a equal ->
@@ -602,7 +605,7 @@ module type DSL = sig
   val map :
     ?pp:'a pp ->
     ?of_string:'a of_string ->
-    ?json:'a encode_json * 'a decode_json ->
+    ?json:'a encode_jsonm * 'a decode_json ->
     ?bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?unboxed_bin:'a encode_bin * 'a decode_bin * 'a size_of ->
     ?equal:'a equal ->

--- a/src/repr/type_json.ml
+++ b/src/repr/type_json.ml
@@ -82,9 +82,9 @@ module Encode = struct
         o e x;
         lexeme e `Oe
 
-  let rec t : type a. a t -> a encode_json = function
+  let rec t : type a. a t -> a encode_jsonm = function
     | Self s -> t s.self_fix
-    | Custom c -> c.encode_json
+    | Custom c -> c.encode_jsonm
     | Map b -> map b
     | Boxed x -> t x
     | Prim t -> prim t
@@ -96,16 +96,16 @@ module Encode = struct
     | Variant v -> variant v
     | Var v -> raise (Unbound_type_variable v)
 
-  and tuple : type a. a tuple -> a encode_json = function
+  and tuple : type a. a tuple -> a encode_jsonm = function
     | Pair (x, y) -> pair (t x) (t y)
     | Triple (x, y, z) -> triple (t x) (t y) (t z)
 
-  and map : type a b. (a, b) map -> b encode_json =
+  and map : type a b. (a, b) map -> b encode_jsonm =
    fun { x; g; _ } ->
     let encode = t x in
     fun e u -> encode e (g u)
 
-  and prim : type a. a prim -> a encode_json = function
+  and prim : type a. a prim -> a encode_jsonm = function
     | Unit -> unit
     | Bool -> bool
     | Char -> char
@@ -116,7 +116,7 @@ module Encode = struct
     | String _ -> string
     | Bytes _ -> bytes
 
-  and record : type a. a record -> a encode_json =
+  and record : type a. a record -> a encode_jsonm =
    fun r ->
     let fields = fields r in
     fun e x ->
@@ -135,10 +135,10 @@ module Encode = struct
         fields;
       lexeme e `Oe
 
-  and variant : type a. a variant -> a encode_json =
+  and variant : type a. a variant -> a encode_jsonm =
    fun v e x -> case_v e (v.vget x)
 
-  and case_v : type a. a case_v encode_json =
+  and case_v : type a. a case_v encode_jsonm =
    fun e c ->
     match c with
     | CV0 c -> string e c.cname0
@@ -148,7 +148,7 @@ module Encode = struct
         t c.ctype1 e v;
         lexeme e `Oe
 
-  let assoc : type a. a t -> (string * a) list encode_json =
+  let assoc : type a. a t -> (string * a) list encode_jsonm =
    fun a ->
     let encode_a = t a in
     fun e l ->

--- a/src/repr/type_json.mli
+++ b/src/repr/type_json.mli
@@ -19,12 +19,12 @@ open Type_core
 val pp : ?minify:bool -> 'a t -> 'a Fmt.t
 val to_string : ?minify:bool -> 'a t -> 'a to_string
 val of_string : 'a t -> 'a of_string
-val encode : 'a t -> 'a encode_json
+val encode : 'a t -> 'a encode_jsonm
 val decode : 'a t -> 'a decode_json
 val decode_jsonm : 'a t -> Jsonm.decoder -> ('a, [ `Msg of string ]) result
 
 val decode_lexemes :
   'a t -> Jsonm.lexeme list -> ('a, [ `Msg of string ]) result
 
-val encode_assoc : 'a t -> (string * 'a) list encode_json
+val encode_assoc : 'a t -> (string * 'a) list encode_jsonm
 val decode_assoc : 'a t -> (string * 'a) list decode_json

--- a/test/repr/main.ml
+++ b/test/repr/main.ml
@@ -75,7 +75,7 @@ let of_hex_string x = Ok (Hex.to_string (`Hex x))
 let hex = T.map T.string ~pp:pp_hex ~of_string:of_hex_string id id
 
 let hex2 =
-  let encode_json e x =
+  let encode_jsonm e x =
     let encode x = ignore (Jsonm.encode e (`Lexeme x)) in
     encode `As;
     encode (`String x);
@@ -101,7 +101,7 @@ let hex2 =
         Alcotest.failf "invalid strings: %a %a" Jsonm.pp_lexeme x
           Jsonm.pp_lexeme y
   in
-  T.map T.string ~json:(encode_json, decode_json) id id
+  T.map T.string ~json:(encode_jsonm, decode_json) id id
 
 let error = Alcotest.testable (fun ppf (`Msg e) -> Fmt.string ppf e) ( = )
 let ok x = Alcotest.result x error


### PR DESCRIPTION
Rename 3 functions and expose a new one to be used from user defined JSON decoders.

`encode_json` -> `encode_jsonm`
`decode_json` -> `decode_jsonm`
`decode_json_lexemes` -> `decode_jsonm_lexemes`
\+ `decode_json `

What do you think?