### PR TITLE
ocamlformat 0.18.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.17.0
+version = 0.18.0
 profile = conventional
 parse-docstrings
 break-infix = fit-or-vertical


### PR DESCRIPTION
Now that Index and Irmin use ocamlformat.0.18.0 this makes everyone's life easier

`dune build @fmt --auto-promote` didn't make any change