### PR TITLE
Extend the implementation of size precomputation for binary codecs

### DIFF
--- a/src/repr/binary_codec.ml
+++ b/src/repr/binary_codec.ml
@@ -285,8 +285,8 @@ module Option = struct
         in
         let of_encoding buf (Size.Offset off) =
           match Stdlib.String.get buf off with
-          | '\000' -> Size.Offset (off + 1)
-          | _ -> Size.Offset (1 + n)
+          | '\000' -> Size.Offset (off + header_size)
+          | _ -> Size.Offset (off + header_size + n)
         in
         Sizer.dynamic ~of_value ~of_encoding
     | elt ->
@@ -300,8 +300,8 @@ module Option = struct
           let+ elt_decode = elt.of_encoding in
           fun buf (Size.Offset off) ->
             match Stdlib.String.get buf off with
-            | '\000' -> Size.Offset (off + 1)
-            | _ -> elt_decode buf (Size.Offset (off + 1))
+            | '\000' -> Size.Offset (off + header_size)
+            | _ -> elt_decode buf (Size.Offset (off + header_size))
         in
         { of_value; of_encoding }
 end

--- a/src/repr/binary_codec.ml
+++ b/src/repr/binary_codec.ml
@@ -1,5 +1,8 @@
 include Binary_codec_intf
+include Binary_codec_intf.Types
+open Type_core
 open Staging
+module Sizer = Size.Sizer
 
 let unsafe_add_bytes b k = k (Bytes.unsafe_to_string b)
 let str = Bytes.unsafe_of_string
@@ -15,11 +18,13 @@ let charstring_of_code : int -> string =
 module Unit = struct
   let encode () _k = ()
   let decode _ ofs = (ofs, ()) [@@inline always]
+  let sizer = Sizer.static 0
 end
 
 module Char = struct
   let encode c k = k (charstring_of_code (Char.code c))
   let decode buf ofs = (ofs + 1, buf.[ofs]) [@@inline always]
+  let sizer = Sizer.static 1
 end
 
 module Bool = struct
@@ -28,6 +33,8 @@ module Bool = struct
   let decode buf ofs =
     let ofs, c = Char.decode buf ofs in
     match c with '\000' -> (ofs, false) | _ -> (ofs, true)
+
+  let sizer = Sizer.static 1
 end
 
 module Int8 = struct
@@ -46,6 +53,7 @@ module Int16 = struct
     unsafe_add_bytes b
 
   let decode buf ofs = (ofs + 2, Bytes.get_uint16_be (str buf) ofs)
+  let sizer = Sizer.static 2
 end
 
 module Int32 = struct
@@ -55,6 +63,7 @@ module Int32 = struct
     unsafe_add_bytes b
 
   let decode buf ofs = (ofs + 4, Bytes.get_int32_be (str buf) ofs)
+  let sizer = Sizer.static 4
 end
 
 module Int64 = struct
@@ -64,6 +73,7 @@ module Int64 = struct
     unsafe_add_bytes b
 
   let decode buf ofs = (ofs + 8, Bytes.get_int64_be (str buf) ofs)
+  let sizer = Sizer.static 8
 end
 
 module Float = struct
@@ -72,6 +82,9 @@ module Float = struct
   let decode buf ofs =
     let ofs, f = Int64.decode buf ofs in
     (ofs, Stdlib.Int64.float_of_bits f)
+
+  (* NOTE: we consider 'double' here *)
+  let sizer = Sizer.static 8
 end
 
 module Int = struct
@@ -92,32 +105,55 @@ module Int = struct
       if i >= 0 && i < 128 then (ofs, n) else aux buf n (p + 7) ofs
     in
     aux buf 0 0 ofs
+
+  let sizer =
+    let of_value =
+      let rec aux len n =
+        if n >= 0 && n < 128 then len else aux (len + 1) (n lsr 7)
+      in
+      fun n -> aux 1 n
+    in
+    let of_encoding buf (Size.Offset off) =
+      Size.Offset (fst (decode buf off))
+    in
+    Sizer.dynamic ~of_value ~of_encoding
 end
 
 module Len = struct
-  let encode n i =
-    match n with
-    | `Int -> Int.encode i
-    | `Int8 -> Int8.encode i
-    | `Int16 -> Int16.encode i
-    | `Int32 -> Int32.encode (Stdlib.Int32.of_int i)
-    | `Int64 -> Int64.encode (Stdlib.Int64.of_int i)
-    | `Fixed _ -> Unit.encode ()
-    | `Unboxed -> Unit.encode ()
+  let encode n =
+    stage (fun i ->
+        match n with
+        | `Int -> Int.encode i
+        | `Int8 -> Int8.encode i
+        | `Int16 -> Int16.encode i
+        | `Int32 -> Int32.encode (Stdlib.Int32.of_int i)
+        | `Int64 -> Int64.encode (Stdlib.Int64.of_int i)
+        | `Fixed _ -> Unit.encode ()
+        | `Unboxed -> Unit.encode ())
 
-  let decode n buf ofs =
-    match n with
-    | `Int -> Int.decode buf ofs
-    | `Int8 -> Int8.decode buf ofs
-    | `Int16 -> Int16.decode buf ofs
-    | `Int32 ->
-        let ofs, i = Int32.decode buf ofs in
-        (ofs, Stdlib.Int32.to_int i)
-    | `Int64 ->
-        let ofs, i = Int64.decode buf ofs in
-        (ofs, Stdlib.Int64.to_int i)
-    | `Fixed n -> (ofs, n)
-    | `Unboxed -> (ofs, String.length buf - ofs)
+  let decode n =
+    stage (fun buf ofs ->
+        match n with
+        | `Int -> Int.decode buf ofs
+        | `Int8 -> Int8.decode buf ofs
+        | `Int16 -> Int16.decode buf ofs
+        | `Int32 ->
+            let ofs, i = Int32.decode buf ofs in
+            (ofs, Stdlib.Int32.to_int i)
+        | `Int64 ->
+            let ofs, i = Int64.decode buf ofs in
+            (ofs, Stdlib.Int64.to_int i)
+        | `Fixed n -> (ofs, n)
+        | `Unboxed -> (ofs, String.length buf - ofs))
+
+  let sizer = function
+    | `Int -> Int.sizer
+    | `Int8 -> Sizer.static 1
+    | `Int16 -> Sizer.static 2
+    | `Int32 -> Sizer.static 4
+    | `Int64 -> Sizer.static 8
+    | `Fixed _ -> Sizer.static 0
+    | `Unboxed -> Sizer.static 0
 end
 
 (* Helper functions generalising over [string] / [bytes]. *)
@@ -144,9 +180,36 @@ module Mono_container = struct
         (* fixed-size strings are never boxed *)
         stage @@ fun buf ofs -> sub n buf ofs
     | n ->
+        let decode_len = unstage (Len.decode n) in
         stage @@ fun buf ofs ->
-        let ofs, len = Len.decode n buf ofs in
+        let ofs, len = decode_len buf ofs in
         sub len buf ofs
+
+  let sizer_unboxed ~length = function
+    | `Fixed n -> Sizer.static n (* fixed-size containers are never boxed *)
+    | _ -> { of_value = Dynamic length; of_encoding = Unknown }
+  (* NOTE: this is the one case where we can't recover the length of an
+     encoding from its initial offset, given a structurally-defined codec. *)
+
+  let sizer ~length header_typ =
+    let size_of_header = (Len.sizer header_typ).of_value in
+    match (size_of_header, header_typ) with
+    | Static n, `Fixed str_len -> Sizer.static (n + str_len)
+    | _, _ -> (
+        let decode_len = unstage (Len.decode header_typ) in
+        let of_encoding buf (Size.Offset off) =
+          let off, size = decode_len buf off in
+          assert (size >= 0);
+          Size.Offset (off + size)
+        in
+        match size_of_header with
+        | Unknown -> assert false
+        | Static n ->
+            Sizer.dynamic ~of_encoding ~of_value:(fun s -> n + length s)
+        | Dynamic f ->
+            Sizer.dynamic ~of_encoding ~of_value:(fun s ->
+                let s_len = length s in
+                f s_len + s_len))
 end
 
 module String_unboxed = struct
@@ -154,6 +217,8 @@ module String_unboxed = struct
 
   let decode _ =
     Mono_container.decode_unboxed (fun x -> x) Bytes.unsafe_to_string
+
+  let sizer n = Mono_container.sizer_unboxed ~length:String.length n
 end
 
 module Bytes_unboxed = struct
@@ -162,26 +227,32 @@ module Bytes_unboxed = struct
 
   let decode _ =
     Mono_container.decode_unboxed Bytes.unsafe_of_string (fun x -> x)
+
+  let sizer n = Mono_container.sizer_unboxed ~length:Bytes.length n
 end
 
 module String = struct
   let encode len =
+    let encode_len = unstage (Len.encode len) in
     stage (fun s k ->
         let i = String.length s in
-        Len.encode len i k;
+        encode_len i k;
         k s)
 
   let decode len = Mono_container.decode (fun x -> x) Bytes.unsafe_to_string len
+  let sizer n = Mono_container.sizer ~length:String.length n
 end
 
 module Bytes = struct
   let encode len =
+    let encode_len = unstage (Len.encode len) in
     stage (fun s k ->
         let i = Bytes.length s in
-        Len.encode len i k;
+        encode_len i k;
         unsafe_add_bytes s k)
 
   let decode len = Mono_container.decode Bytes.unsafe_of_string (fun x -> x) len
+  let sizer len = Mono_container.sizer ~length:Bytes.length len
 end
 
 module Option = struct
@@ -199,6 +270,112 @@ module Option = struct
     | _ ->
         let ofs, x = decode_elt buf ofs in
         (ofs, Some x)
+
+  let sizer : type a. a Sizer.t -> a option Sizer.t =
+   fun elt ->
+    let header_size = 1 in
+    match elt with
+    | { of_value = Static 0; _ } ->
+        Sizer.static header_size (* Either '\000' or '\255' *)
+    | { of_value = Static n; _ } ->
+        (* Must add [n] in the [Some _] case, otherwise just header size. *)
+        let of_value = function
+          | None -> header_size
+          | Some _ -> header_size + n
+        in
+        let of_encoding buf (Size.Offset off) =
+          match Stdlib.String.get buf off with
+          | '\000' -> Size.Offset (off + 1)
+          | _ -> Size.Offset (1 + n)
+        in
+        Sizer.dynamic ~of_value ~of_encoding
+    | elt ->
+        (* Must dynamically compute element size in the [Some _] case. *)
+        let open Size.Syntax in
+        let of_value =
+          let+ elt_encode = elt.of_value in
+          function None -> header_size | Some x -> header_size + elt_encode x
+        in
+        let of_encoding =
+          let+ elt_decode = elt.of_encoding in
+          fun buf (Size.Offset off) ->
+            match Stdlib.String.get buf off with
+            | '\000' -> Size.Offset (off + 1)
+            | _ -> elt_decode buf (Size.Offset (off + 1))
+        in
+        { of_value; of_encoding }
+end
+
+(* Helper functions generalising over [list] / [array]. *)
+module Poly_container = struct
+  let sizer :
+      type a at.
+      length:(at -> int) ->
+      fold_left:(f:(int -> a -> int) -> init:int -> at -> int) ->
+      len ->
+      a sizer ->
+      at sizer =
+   fun ~length ~fold_left header_typ elt_size ->
+    let header_size = (Len.sizer header_typ).of_value in
+    match (header_typ, header_size, elt_size) with
+    | _, Size.Unknown, _ -> assert false
+    | `Fixed length, Static header_size, { of_value = Static elt_size; _ } ->
+        (* We don't serialise headers for fixed-size containers *)
+        assert (header_size = 0);
+        Sizer.static (length * elt_size)
+    | _, _, { of_value = Static elt_size; _ } ->
+        let of_value =
+          (* Number of elements not fixed, so we must check it dynamically *)
+          match header_size with
+          | Unknown -> assert false
+          | Static header_size ->
+              fun l ->
+                let nb_elements = length l in
+                header_size + (elt_size * nb_elements)
+          | Dynamic header_size ->
+              fun l ->
+                let nb_elements = length l in
+                header_size nb_elements + (elt_size * nb_elements)
+        in
+        let of_encoding =
+          (* Read the header to recover the length. Don't need to look at
+             elements as they have static size. *)
+          let decode_len = unstage (Len.decode header_typ) in
+          fun buf (Size.Offset off) ->
+            let off, elements = decode_len buf off in
+            Size.Offset (off + (elt_size * elements))
+        in
+        Sizer.dynamic ~of_value ~of_encoding
+    | _ ->
+        let open Size.Syntax in
+        let of_value =
+          (* Must traverse the container _and_ compute element sizes
+             individually *)
+          let+ elt_size = elt_size.of_value in
+          match header_size with
+          | Unknown -> assert false
+          | Static header_size ->
+              fun l ->
+                fold_left l ~init:header_size ~f:(fun acc x -> acc + elt_size x)
+          | Dynamic header_size ->
+              fun l ->
+                let len = length l in
+                let header_size = header_size len in
+                fold_left l ~init:header_size ~f:(fun acc x -> acc + elt_size x)
+        in
+        let of_encoding =
+          let+ elt_decode = elt_size.of_encoding in
+          let rec decode_elements buf off todo =
+            match todo with
+            | 0 -> off
+            | n -> decode_elements buf (elt_decode buf off) (n - 1)
+          in
+          let decode_len = unstage (Len.decode header_typ) in
+          fun buf (Size.Offset off) ->
+            let off, elements = decode_len buf off in
+            decode_elements buf (Size.Offset off) elements
+        in
+        { of_value; of_encoding }
 end
 
 module List = struct
@@ -210,8 +387,9 @@ module List = struct
           (encode_elements [@tailcall]) encode_elt k xs
     in
     fun len encode_elt ->
+      let encode_len = unstage (Len.encode len) in
       stage (fun x k ->
-          Len.encode len (List.length x) k;
+          encode_len (List.length x) k;
           encode_elements encode_elt k x)
 
   let decode =
@@ -222,9 +400,14 @@ module List = struct
           decode_elements decode_elt (x :: acc) buf off (n - 1)
     in
     fun len decode_elt ->
+      let decode_len = unstage (Len.decode len) in
       stage (fun buf ofs ->
-          let ofs, len = Len.decode len buf ofs in
+          let ofs, len = decode_len buf ofs in
           decode_elements decode_elt [] buf ofs len)
+
+  let sizer len elt =
+    Poly_container.sizer ~length:List.length ~fold_left:ListLabels.fold_left len
+      elt
 end
 
 module Array = struct
@@ -235,8 +418,9 @@ module Array = struct
       done
     in
     fun n l ->
+      let encode_len = unstage (Len.encode n) in
       stage (fun x k ->
-          Len.encode n (Array.length x) k;
+          encode_len (Array.length x) k;
           encode_elements l k x)
 
   let decode len decode_elt =
@@ -244,6 +428,10 @@ module Array = struct
     stage (fun buf off ->
         let ofs, l = list_decode buf off in
         (ofs, Array.of_list l))
+
+  let sizer len elt =
+    Poly_container.sizer ~length:Array.length ~fold_left:ArrayLabels.fold_left
+      len elt
 end
 
 module Pair = struct
@@ -255,6 +443,8 @@ module Pair = struct
     let off, a = a buf off in
     let off, b = b buf off in
     (off, (a, b))
+
+  let sizer a b = Sizer.(using fst a <+> using snd b)
 end
 
 module Triple = struct
@@ -268,4 +458,10 @@ module Triple = struct
     let off, b = b buf off in
     let off, c = c buf off in
     (off, (a, b, c))
+
+  let sizer a b c =
+    Sizer.(
+      using (fun (x, _, _) -> x) a
+      <+> using (fun (_, x, _) -> x) b
+      <+> using (fun (_, _, x) -> x) c)
 end

--- a/src/repr/binary_codec.ml
+++ b/src/repr/binary_codec.ml
@@ -276,7 +276,8 @@ module Option = struct
     let header_size = 1 in
     match elt with
     | { of_value = Static 0; _ } ->
-        Sizer.static header_size (* Either '\000' or '\255' *)
+        (* Either '\000' or '\255'; [a] has an empty encoding. *)
+        Sizer.static header_size
     | { of_value = Static n; _ } ->
         (* Must add [n] in the [Some _] case, otherwise just header size. *)
         let of_value = function

--- a/src/repr/binary_codec_intf.ml
+++ b/src/repr/binary_codec_intf.ml
@@ -1,14 +1,20 @@
 open Type_core
 open Staging
 
-type 'a encoder = 'a -> (string -> unit) -> unit
-type 'a decoder = string -> int -> int * 'a
+module Types = struct
+  type 'a encoder = 'a -> (string -> unit) -> unit
+  type 'a decoder = string -> int -> int * 'a
+  type 'a sizer = 'a Size.Sizer.t
+end
+
+open Types
 
 module type S = sig
   type t
 
   val encode : t encoder
   val decode : t decoder
+  val sizer : t sizer
 end
 
 module type S_with_length = sig
@@ -16,6 +22,7 @@ module type S_with_length = sig
 
   val encode : len -> t encoder staged
   val decode : len -> t decoder staged
+  val sizer : len -> t sizer
 end
 
 module type S1 = sig
@@ -23,6 +30,7 @@ module type S1 = sig
 
   val encode : 'a encoder -> 'a t encoder
   val decode : 'a decoder -> 'a t decoder
+  val sizer : 'a sizer -> 'a t sizer
 end
 
 module type S1_with_length = sig
@@ -30,6 +38,7 @@ module type S1_with_length = sig
 
   val encode : len -> 'a encoder -> 'a t encoder staged
   val decode : len -> 'a decoder -> 'a t decoder staged
+  val sizer : len -> 'a sizer -> 'a t sizer
 end
 
 module type S2 = sig
@@ -37,6 +46,7 @@ module type S2 = sig
 
   val encode : 'a encoder -> 'b encoder -> ('a, 'b) t encoder
   val decode : 'a decoder -> 'b decoder -> ('a, 'b) t decoder
+  val sizer : 'a sizer -> 'b sizer -> ('a, 'b) t sizer
 end
 
 module type S3 = sig
@@ -44,9 +54,12 @@ module type S3 = sig
 
   val encode : 'a encoder -> 'b encoder -> 'c encoder -> ('a, 'b, 'c) t encoder
   val decode : 'a decoder -> 'b decoder -> 'c decoder -> ('a, 'b, 'c) t decoder
+  val sizer : 'a sizer -> 'b sizer -> 'c sizer -> ('a, 'b, 'c) t sizer
 end
 
 module type Intf = sig
+  include module type of Types
+
   module type S = S
   module type S1 = S1
   module type S2 = S2

--- a/src/repr/size.ml
+++ b/src/repr/size.ml
@@ -1,0 +1,79 @@
+type 'a t = Static of int | Dynamic of 'a | Unknown
+type 'a size = 'a t
+
+let map : type a b. (a -> b) -> a t -> b t =
+ fun f -> function
+  | Unknown -> Unknown
+  | Static n -> Static n
+  | Dynamic a -> Dynamic (f a)
+
+module Syntax = struct
+  let ( let+ ) x f = map f x
+end
+
+(** A type wrapper for positional offsets into buffers (as opposed to e.g.
+    lengths of values in those buffers). *)
+type offset = Offset of int [@@unboxed]
+
+module Offset = struct
+  type t = offset
+
+  let ( +> ) : t -> int -> t = fun (Offset n) m -> Offset (n + m)
+  let ( <+ ) : int -> t -> t = fun n (Offset m) -> Offset (n + m)
+end
+
+module Sizer = struct
+  type 'a t = {
+    of_value : ('a -> int) size;
+    of_encoding : (string -> Offset.t -> Offset.t) size;
+  }
+  (** An ['a t] is a value that represents the size information known about a
+      particular codec for type ['a].
+
+      - [of_value]: given a value to encode, return the size of its encoding.
+
+      - [of_encoding]: given a buffer [buf] and an offset [off], return the
+        _offset_ immediately _after_ the encoding starting at [buf.\[off\]]
+        NOTE: not the length of the encoding itself, to enable chains of such
+        sizers to call each other in tail-position.
+
+      Invariant: [∀ n. (of_value = Static n) ⟺ (of_encoding = Static n)]. *)
+
+  let ( <+> ) : type a. a t -> a t -> a t =
+    let add_of_value (a : _ size) (b : _ size) : _ size =
+      match (a, b) with
+      | Unknown, _ | _, Unknown -> Unknown
+      | Static a, Static b -> Static (a + b)
+      | Static 0, other | other, Static 0 -> other
+      | Static n, Dynamic f | Dynamic f, Static n -> Dynamic (fun a -> n + f a)
+      | Dynamic f, Dynamic g -> Dynamic (fun a -> f a + g a)
+    in
+    let add_of_encoding (a : _ size) (b : _ size) : _ size =
+      match (a, b) with
+      | Unknown, _ | _, Unknown -> Unknown
+      | Static a, Static b -> Static (a + b)
+      | Static 0, other | other, Static 0 -> other
+      | Dynamic f, Dynamic g -> Dynamic (fun buf off -> g buf (f buf off))
+      (* NOTE: in these cases we could be slightly more efficient by storing a
+         vector of sizing functions inside [Dynamic], which would allow constant
+         folding for static segments of dynamically-sized types. *)
+      | Static n, Dynamic f -> Dynamic (fun buf off -> f buf Offset.(off +> n))
+      | Dynamic f, Static n -> Dynamic (fun buf off -> Offset.(f buf off +> n))
+    in
+    fun a b ->
+      {
+        of_value = add_of_value a.of_value b.of_value;
+        of_encoding = add_of_encoding a.of_encoding b.of_encoding;
+      }
+
+  let static n = { of_value = Static n; of_encoding = Static n }
+
+  let dynamic ~of_value ~of_encoding =
+    { of_value = Dynamic of_value; of_encoding = Dynamic of_encoding }
+
+  let using f t =
+    let of_value = map (fun size_of x -> size_of (f x)) t.of_value in
+    { t with of_value }
+
+  let unknown = { of_value = Unknown; of_encoding = Unknown }
+end

--- a/src/repr/type_binary.ml
+++ b/src/repr/type_binary.ml
@@ -255,12 +255,16 @@ module Unboxed = struct
   let decode_bin = Decode.unboxed
 end
 
-let to_bin size_of encode_bin =
-  let size_of = unstage size_of in
+let to_bin (size_of : _ Size.Sizer.t) encode_bin =
   let encode_bin = unstage encode_bin in
   stage (fun x ->
       let seq = encode_bin x in
-      let len = match size_of x with None -> 1024 | Some n -> n in
+      let len =
+        match size_of.of_value with
+        | Static n -> n
+        | Dynamic f -> f x
+        | Unknown -> 1024
+      in
       let buf = Buffer.create len in
       seq (Buffer.add_string buf);
       Buffer.contents buf)

--- a/src/repr/type_core.ml
+++ b/src/repr/type_core.ml
@@ -50,6 +50,10 @@ let annotate t ~add ~data =
   | Attributes t -> Attributes { t with attrs = add data t.attrs }
   | t -> Attributes { attrs = add data Attribute.Map.empty; attr_type = t }
 
+let unimplemented_size_of =
+  let f _ = failwith "`size_of` not implemented" in
+  Size.Sizer.{ of_value = Dynamic f; of_encoding = Dynamic f }
+
 let partial ?(pp = fun _ -> failwith "`pp` not implemented")
     ?(of_string = fun _ -> failwith "`of_string` not implemented")
     ?(encode_json = fun _ -> failwith "`encode_json` not implemented")
@@ -61,13 +65,12 @@ let partial ?(pp = fun _ -> failwith "`pp` not implemented")
     ?(equal = stage (fun _ -> failwith "`equal` not implemented"))
     ?(encode_bin = stage (fun _ -> failwith "`encode_bin` not implemented"))
     ?(decode_bin = stage (fun _ -> failwith "`decode_bin` not implemented"))
-    ?(size_of = stage (fun _ -> failwith "`size_of` not implemented"))
+    ?(size_of = unimplemented_size_of)
     ?(unboxed_encode_bin =
       stage (fun _ -> failwith "`unboxed_encode_bin` not implemented"))
     ?(unboxed_decode_bin =
       stage (fun _ -> failwith "`unboxed_decode_bin` not implemented"))
-    ?(unboxed_size_of =
-      stage (fun _ -> failwith "`unboxed_size_of` not implemented")) () =
+    ?(unboxed_size_of = unimplemented_size_of) () =
   Custom
     {
       cwit = `Witness (Witness.make ());

--- a/src/repr/type_core_intf.ml
+++ b/src/repr/type_core_intf.ml
@@ -12,7 +12,7 @@ module Types = struct
   type 'a pre_hash = 'a bin_seq staged
   type 'a encode_bin = 'a bin_seq staged
   type 'a decode_bin = (string -> int -> int * 'a) staged
-  type 'a size_of = ('a -> int option) staged
+  type 'a size_of = 'a Size.Sizer.t
   type 'a compare = ('a -> 'a -> int) staged
   type 'a equal = ('a -> 'a -> bool) staged
   type 'a short_hash = (?seed:int -> 'a -> int) staged
@@ -136,6 +136,7 @@ module type Type_core = sig
   include module type of Types
   (** @inline *)
 
+  val unimplemented_size_of : 'a size_of
   val fields : 'a record -> 'a a_field list
 
   module Fields_folder (Acc : sig

--- a/src/repr/type_pp.ml
+++ b/src/repr/type_pp.ml
@@ -30,6 +30,7 @@ let t t =
    fun t ppf x ->
     match t with
     | Self s -> aux s.self_fix ppf x
+    | Attributes { attr_type; _ } -> aux attr_type ppf x
     | Custom c -> c.pp ppf x
     | Map m -> map m ppf x
     | Prim p -> prim p ppf x
@@ -249,6 +250,7 @@ let of_string t =
    fun t x ->
     match t with
     | Self s -> aux s.self_fix x
+    | Attributes { attr_type; _ } -> aux attr_type x
     | Custom c -> c.of_string x
     | Map m -> aux m.x x |> map_result m.f
     | Prim p -> prim p x

--- a/src/repr/type_size.mli
+++ b/src/repr/type_size.mli
@@ -16,5 +16,5 @@
 
 open Type_core
 
-val t : 'a t -> 'a size_of
-val unboxed : 'a t -> 'a size_of
+val t : 'a t -> 'a Size.Sizer.t
+val unboxed : 'a t -> 'a Size.Sizer.t

--- a/test/repr/import.ml
+++ b/test/repr/import.ml
@@ -1,0 +1,10 @@
+module Alcotest = struct
+  include Alcotest
+
+  let gcheck ?pos typ msg a b =
+    let equal = Repr.(unstage (equal typ)) in
+    let pp = Repr.pp_dump typ in
+    check ?pos (testable pp equal) msg a b
+
+  let string = testable Fmt.Dump.string String.equal
+end

--- a/test/repr/test_size_of.ml
+++ b/test/repr/test_size_of.ml
@@ -106,16 +106,26 @@ let test_container () =
     type two = bool * bool [@@deriving repr]
     type three = bool * bool * bool [@@deriving repr]
 
-    let thirty_t = T.(list ~len:(`Fixed 10) three_t)
     let two = (true, true)
     let three = (true, true, true)
     let thirty = List.init 10 (fun _ -> three)
+    let thirty_t = T.(list ~len:(`Fixed 10) three_t)
   end in
   let open X in
   check_static ~__POS__ two_t 2 two;
   check_static ~__POS__ three_t 3 three;
   check_static ~__POS__ thirty_t (3 * 10) thirty;
-  check_static ~__POS__ T.(triple char int32 int64) (1 + 4 + 8) ('1', 4l, 8L)
+  check_static ~__POS__ [%typ: char * int32 * int64] (1 + 4 + 8) ('1', 4l, 8L);
+
+  (* Option with statically sized elements *)
+  check_dynamic ~__POS__ [%typ: bool option list]
+    (1 + (2 + 1 + 2))
+    [ Some true; None; Some false ];
+
+  (* Option with dynamically sized elements *)
+  check_dynamic ~__POS__ [%typ: int option list]
+    (1 + (2 + 1 + 3 + 1 + 4))
+    [ Some 1; None; Some (1 lsl 7); None; Some (1 lsl 14) ]
 
 let test_variant () =
   let module X = struct

--- a/test/repr/test_size_of.ml
+++ b/test/repr/test_size_of.ml
@@ -1,0 +1,186 @@
+module T = Repr
+
+let encode_bin t = T.(unstage (encode_bin t))
+
+let encode_bin typ v =
+  let buffer = Buffer.create 0 in
+  encode_bin typ v (Buffer.add_string buffer);
+  Buffer.contents buffer
+
+let random_string len = String.init len (fun _ -> char_of_int (Random.int 256))
+
+let check_unknown ~__POS__:pos typ =
+  match T.Size.of_value typ with
+  | Unknown -> ()
+  | Dynamic _ | Static _ ->
+      Alcotest.failf ~pos
+        "Expected type to have unknown size, but (Dynamic _ | Static _) was \
+         received."
+
+let check_static ~__POS__:pos typ expected v =
+  match T.Size.of_value typ with
+  | Unknown | Dynamic _ ->
+      Alcotest.failf ~pos
+        "Expected type to have static size %d, but (Unknown | Dynamic _) was \
+         received."
+        expected
+  | Static n ->
+      Alcotest.(check ~pos int) "Expected static size" expected n;
+
+      (* Check that the encoding actually occupies [n] bytes *)
+      let actual_size = String.length (encode_bin typ v) in
+      Alcotest.(check ~pos int)
+        "Actual size must match static spec" expected actual_size
+
+let check_dynamic ~__POS__:pos typ expected v =
+  Fmt.pr "Testing type: %a@." T.pp_ty typ;
+  let unexpected fmt =
+    Alcotest.failf ~pos
+      ("Expected type to have dynamic size, but " ^^ fmt ^^ " was received.")
+  in
+  match T.Size.(of_value typ, of_encoding typ) with
+  | Unknown, _ | _, Unknown -> unexpected "Unknown"
+  | Static n, _ | _, Static n -> unexpected "Static %d" n
+  | Dynamic encode, Dynamic decode ->
+      Alcotest.(check ~pos int) "Expected dynamic size" expected (encode v);
+
+      (* Check that the encoding actually occupies [n] bytes *)
+      let encoding = encode_bin typ v in
+      let actual_size = String.length encoding in
+      Alcotest.(check ~pos int)
+        "Actual size must match dynamic spec" expected actual_size;
+
+      (* Check that the size is correctly recovered from the encoding, even after
+         adding some random surrounding context. *)
+      let left_pad = 1 in
+      let right_pad = 0 in
+      let wrapped_encoding =
+        random_string left_pad ^ encoding ^ random_string right_pad
+      in
+      let recovered_length = decode wrapped_encoding left_pad in
+      Fmt.epr "wrapped_encoding (left %d, right %d): %a@." left_pad right_pad
+        Fmt.(Dump.list (fun ppf x -> Fmt.pf ppf "%d" x))
+        (String.to_seq wrapped_encoding |> List.of_seq |> List.map Char.code);
+      Alcotest.(check ~pos int)
+        "Recovered length must match dynamic spec" expected recovered_length
+
+let test_primitive () =
+  check_static ~__POS__ T.unit 0 ();
+  check_static ~__POS__ T.bool 1 true;
+  check_static ~__POS__ T.char 1 ' ';
+  check_static ~__POS__ T.int32 4 1l;
+  check_static ~__POS__ T.int64 8 (-1L);
+  check_static ~__POS__ T.float 8 Float.nan
+
+let test_int () =
+  let test_cases =
+    (* Test a range of integers that fit correctly on this platform *)
+    [
+      (__POS__, 7);
+      (__POS__, 14);
+      (__POS__, 21);
+      (__POS__, 28);
+      (__POS__, 35);
+      (__POS__, 42);
+      (__POS__, 49);
+      (__POS__, 56);
+    ]
+    |> List.filter (fun (_, i) -> i < Sys.int_size)
+    |> List.map (fun (p, i) -> (p, 1 lsl i))
+  in
+  ListLabels.iteri test_cases ~f:(fun i (pos, p) ->
+      check_dynamic ~__POS__:pos T.int (i + 1) (p - 1);
+      check_dynamic ~__POS__:pos T.int (i + 2) p)
+
+let test_container () =
+  let module X = struct
+    type two = bool * bool [@@deriving repr]
+    type three = bool * bool * bool [@@deriving repr]
+
+    let thirty_t = T.(list ~len:(`Fixed 10) three_t)
+    let two = (true, true)
+    let three = (true, true, true)
+    let thirty = List.init 10 (fun _ -> three)
+  end in
+  let open X in
+  check_static ~__POS__ two_t 2 two;
+  check_static ~__POS__ three_t 3 three;
+  check_static ~__POS__ thirty_t (3 * 10) thirty;
+  check_static ~__POS__ T.(triple char int32 int64) (1 + 4 + 8) ('1', 4l, 8L)
+
+let test_variant () =
+  let module X = struct
+    type enum = A | B | C [@@deriving repr]
+    type enum' = A | B of unit [@@deriving repr]
+    type equal_size = A of bool | B of char [@@deriving repr]
+
+    type mixed = Argless | Unit of unit | Char of char | Int of int
+    [@@deriving repr]
+  end in
+  let open X in
+  check_static ~__POS__ enum_t 1 A;
+  check_static ~__POS__ enum'_t 1 (B ());
+  check_static ~__POS__ equal_size_t 2 (A true);
+  check_static ~__POS__ [%typ: unit option] 1 None;
+
+  check_dynamic ~__POS__ mixed_t 1 Argless
+
+let test_recursive () =
+  let module X = struct
+    type int_list = [] | ( :: ) of int * int_list [@@deriving repr]
+
+    type int_tree = Leaf of int | Branch of int_tree * int_tree
+    [@@deriving repr]
+
+    type odd = S of even
+
+    and even = Z | S' of odd [@@deriving repr]
+  end in
+  let open X in
+  check_dynamic ~__POS__ int_list_t 1 [];
+  check_dynamic ~__POS__ int_list_t 7 [ 1; 2; 3 ];
+
+  let leaf_size = 2 (* tag + short int *) in
+  let branch_size = 1 (* tag, excluding subterms *) in
+  check_dynamic ~__POS__ int_tree_t leaf_size (Leaf 0);
+  check_dynamic ~__POS__ int_tree_t
+    (branch_size + (2 * leaf_size))
+    (Branch (Leaf 1, Leaf 2));
+  check_dynamic ~__POS__ int_tree_t
+    ((3 * branch_size) + (4 * leaf_size))
+    (Branch (Branch (Leaf 1, Leaf 2), Branch (Leaf 3, Leaf 4)));
+
+  check_dynamic ~__POS__ even_t 1 Z;
+  check_dynamic ~__POS__ odd_t 2 (S Z);
+  check_dynamic ~__POS__ even_t 3 (S' (S Z));
+  check_dynamic ~__POS__ odd_t 4 (S (S' (S Z)));
+
+  let faux_recursive_t = T.(mu (fun _ -> char)) in
+  check_static ~__POS__ faux_recursive_t 1 'a'
+
+let test_unknown () =
+  let module X = struct
+    type opaque = Opaque [@@deriving repr]
+
+    let opaque_t =
+      let encode_bin = T.(encode_bin opaque_t) in
+      let decode_bin = T.(decode_bin opaque_t) in
+      let size_of = T.Size.custom_dynamic () in
+      T.like ~bin:(encode_bin, decode_bin, size_of) opaque_t
+
+    type int_list = Cons of int * int_list | Nil of opaque [@@deriving repr]
+  end in
+  let open X in
+  check_unknown ~__POS__ opaque_t;
+  check_unknown ~__POS__ int_list_t;
+  ()
+
+let tests =
+  [
+    ("primitive", `Quick, test_primitive);
+    ("int", `Quick, test_int);
+    ("container", `Quick, test_container);
+    ("variant", `Quick, test_variant);
+    ("recursive", `Quick, test_recursive);
+    ("unknown", `Quick, test_unknown);
+  ]

--- a/test/repr/test_size_of.mli
+++ b/test/repr/test_size_of.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list


### PR DESCRIPTION
The implementation now makes a distinction between three states of knowledge about the size of a codec:

- `Static n`: the encoding always occupies exactly `n` bytes;
- `Dynamic f`: the encoding has variable size, pre-computed by `f`;
- `Unknown`: the encoding size cannot be efficiently pre-computed.

This allows some of the work in determining the size of a codec to be computed at specialisation time, cutting down significantly on the allocation cost.

Additionally, the implementation is now also able to efficiently _recover_ the size of an encoding given a pointer to the start of that encoding (i.e. without actually decoding the value). In this case, `Dynamic f` is a function that decodes the size of an encoding, and `Unknown` signifies that this cannot be done (e.g. for unboxed values).

Fixes https://github.com/mirage/repr/issues/65. Depends on https://github.com/mirage/repr/pull/68.