### PR TITLE
Fix `Repr.pre_hash` to rely on itself recursively

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
   and `Repr.like` must now pass a sizer built using `Repr.Size.custom_*`. (#69,
   @CraigFe)
 
+- Fix `Repr.pre_hash` to rely on itself recursively. This ensures that custom
+  `pre_hash` functions attached to components of larger types are not ignored.
+  (#71, @CraigFe)
+
 ### 0.3.0 (2021-04-30)
 
 - `Repr.v` is now called `Repr.abstract`. (#52, @CraigFe)

--- a/src/repr/type_binary.ml
+++ b/src/repr/type_binary.ml
@@ -306,3 +306,15 @@ let of_bin_string t =
   in
   let f = unstage (aux t) in
   stage (fun x -> try f x with Invalid_argument e -> Error (`Msg e))
+
+let pre_hash t =
+  let rec aux : type a. a t -> a encode_bin = function
+    | Attributes { attr_type; _ } -> aux attr_type
+    | Self s -> aux s.self_fix
+    | Map m ->
+        let dst = unstage (aux m.x) in
+        stage (fun v -> dst (m.g v))
+    | Custom c -> c.pre_hash
+    | t -> Unboxed.encode_bin t
+  in
+  aux t

--- a/src/repr/type_binary.mli
+++ b/src/repr/type_binary.mli
@@ -17,6 +17,7 @@
 open Type_core
 open Staging
 
+val pre_hash : 'a t -> 'a encode_bin
 val encode_bin : 'a t -> 'a encode_bin
 val decode_bin : 'a t -> 'a decode_bin
 

--- a/test/repr/main.ml
+++ b/test/repr/main.ml
@@ -926,4 +926,5 @@ let () =
           ("test_stdlib_containers", `Quick, test_stdlib_containers);
         ] );
       ("size_of", Test_size_of.tests);
+      ("pre_hash", Test_pre_hash.tests);
     ]

--- a/test/repr/test_pre_hash.ml
+++ b/test/repr/test_pre_hash.ml
@@ -1,3 +1,18 @@
+let check_string_eq pos ~expected actual =
+  Alcotest.(check ~pos string) "" expected actual
+
+let check_string_neq pos x y = Alcotest.(check ~pos (neg string)) "" x y
+
+let to_to_string : type a. (a -> (string -> unit) -> unit) -> a -> string =
+ fun encoder ->
+  let buf = Buffer.create 0 in
+  fun x ->
+    let append_string = Buffer.add_string buf in
+    encoder x append_string;
+    let result = Buffer.contents buf in
+    Buffer.clear buf;
+    result
+
 (* Test that an overridden [pre_hash] function nested inside a large type is
    used correctly. *)
 let test_nested_custom () =
@@ -9,25 +24,36 @@ let test_nested_custom () =
       let pre_hash = Repr.stage (fun { pre_hash; _ } f -> f pre_hash) in
       Repr.like ~pre_hash custom_t
 
-    type pair = custom * custom [@@deriving repr]
+    type pair = custom * custom [@@deriving repr ~pre_hash]
   end in
-  let pre_hash_string =
-    let writer = Repr.(unstage (pre_hash X.pair_t)) in
-    let buf = Buffer.create 0 in
-    fun x ->
-      writer x (Buffer.add_string buf);
-      Buffer.contents buf
-  in
+  let pre_hash_pair = to_to_string X.pre_hash_pair in
   let input =
     ( { X.pre_hash = "a"; ignored_data = 0 },
       { X.pre_hash = "b"; ignored_data = 0 } )
   in
-  let expected_output =
-    (* Pre-hash of the pair is the concatenation of the precomputed component
-       pre-hashes. *)
-    "ab"
-  in
-  Alcotest.(check ~pos:__POS__ (testable Fmt.Dump.string String.equal))
-    "" expected_output (pre_hash_string input)
+  (* Pre-hash of the pair is the concatenation of the precomputed component
+     pre-hashes. *)
+  check_string_eq __POS__ ~expected:"ab" (pre_hash_pair input)
 
-let tests = [ ("nested custom", `Quick, test_nested_custom) ]
+(* Tests that the pre-hashing function for a given representable type [t] is
+   injective (i.e. that two non-equal values of type [t] always have non-equal
+   pre-hashes). A non-injective pre-hash function would be subject to preimage
+   attacks. *)
+let test_injective () =
+  let module X = struct
+    type string_pair = string * string [@@deriving repr ~pre_hash]
+  end in
+  (* Test that pair components are boxed: *)
+  let () =
+    let pre_hash = to_to_string X.pre_hash_string_pair in
+    let x = pre_hash ("a", "b") in
+    let y = pre_hash ("ab", "") in
+    check_string_neq __POS__ x y
+  in
+  ()
+
+let tests =
+  [
+    ("nested custom", `Quick, test_nested_custom);
+    ("injective", `Quick, test_injective);
+  ]

--- a/test/repr/test_pre_hash.ml
+++ b/test/repr/test_pre_hash.ml
@@ -1,0 +1,33 @@
+(* Test that an overridden [pre_hash] function nested inside a large type is
+   used correctly. *)
+let test_nested_custom () =
+  let module X = struct
+    (* A type that stores its [pre_hash] directly: *)
+    type custom = { pre_hash : string; ignored_data : int } [@@deriving repr]
+
+    let custom_t =
+      let pre_hash = Repr.stage (fun { pre_hash; _ } f -> f pre_hash) in
+      Repr.like ~pre_hash custom_t
+
+    type pair = custom * custom [@@deriving repr]
+  end in
+  let pre_hash_string =
+    let writer = Repr.(unstage (pre_hash X.pair_t)) in
+    let buf = Buffer.create 0 in
+    fun x ->
+      writer x (Buffer.add_string buf);
+      Buffer.contents buf
+  in
+  let input =
+    ( { X.pre_hash = "a"; ignored_data = 0 },
+      { X.pre_hash = "b"; ignored_data = 0 } )
+  in
+  let expected_output =
+    (* Pre-hash of the pair is the concatenation of the precomputed component
+       pre-hashes. *)
+    "ab"
+  in
+  Alcotest.(check ~pos:__POS__ (testable Fmt.Dump.string String.equal))
+    "" expected_output (pre_hash_string input)
+
+let tests = [ ("nested custom", `Quick, test_nested_custom) ]

--- a/test/repr/test_pre_hash.mli
+++ b/test/repr/test_pre_hash.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list


### PR DESCRIPTION
This ensures that custom `pre_hash` functions attached to components of larger types are not ignored.

Fix https://github.com/mirage/repr/issues/39.