### PR TITLE
Add `Repr.int63` as a representation of the `Optint.Int63.t` type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+- Add `Repr.int63`, a representation of the `Optint.Int63.t` type (provided by
+  the `optint` library). (#80, @CraigFe)
+
 - Change `Repr.{like,map,partially_abstract}` functions to not require `_
   staged` wrappers around any (monomorphic) overrides. (#77, @CraigFe)
 

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,8 @@
   uutf
   either
   (jsonm (>= 1.0.0))
-  (base64 (>= 3.0.0)))
+  (base64 (>= 3.0.0))
+  (optint (>= 0.1.0)))
  (synopsis "Dynamic type representations. Provides no stability guarantee")
  (description "\
 This package defines a library of combinators for building dynamic type
@@ -38,6 +39,7 @@ guarantee.
   fmt
   ; Test dependencies inherited from [repr] (see [test/repr/dune])
   (hex :with-test)
+  (optint (and (>= 0.1.0) :with-test))
   (alcotest (and (>= 1.4.0) :with-test)))
  ;; See https://github.com/mirage/repr/issues/48
  ;; Can be removed once using Ppxlib >= 0.16.0

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_deriving"
   "fmt"
   "hex" {with-test}
+  "optint" {>= "0.1.0" & with-test}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/repr.opam
+++ b/repr.opam
@@ -23,6 +23,7 @@ depends: [
   "either"
   "jsonm" {>= "1.0.0"}
   "base64" {>= "3.0.0"}
+  "optint" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/ppx_repr/lib/dsl.ml
+++ b/src/ppx_repr/lib/dsl.ml
@@ -31,6 +31,7 @@ let basic =
     "char";
     "int";
     "int32";
+    "int63";
     "int64";
     "float";
     "string";
@@ -54,8 +55,10 @@ let type_to_combinator_name : longident -> string option =
       List.map type_in_default_scope basic
       (* Types named [t] within their own modules: *)
       @ List.map type_in_separate_module (basic @ containers)
-      (* Technically [lazy_t] is not for direct use, but derive anyway *)
+      (* Technically [lazy_t] is not for direct use, but derive anyway: *)
       @ [ (Lident "lazy_t", "lazy_t"); (Ldot (Lident "Lazy", "t"), "lazy_t") ]
+      (* [Int63.t] may be namespaced under [Optint.Int63.t]: *)
+      @ [ (Ldot (Ldot (Lident "Optint", "Int63"), "t"), "int63") ]
     in
     List.to_seq assoc |> Hashtbl.of_seq
   in

--- a/src/repr/dune
+++ b/src/repr/dune
@@ -1,4 +1,10 @@
 (library
  (name repr)
  (public_name repr)
- (libraries base64 fmt jsonm uutf either))
+ (libraries
+  base64
+  fmt
+  jsonm
+  uutf
+  either
+  (re_export optint)))

--- a/src/repr/type.ml
+++ b/src/repr/type.ml
@@ -480,6 +480,19 @@ module Attribute = struct
   let set_random f ty = annotate ~add:Type_random.Attr.add ~data:f ty
 end
 
+let int63 =
+  let module I = Optint.Int63 in
+  let random : Stdlib.Random.State.t -> I.t =
+    match I.is_immediate with
+    | True -> unstage (random_state int)
+    | False ->
+        let random_int64 = unstage (random_state int64) in
+        fun s -> I.of_int64 (Int64.shift_right (random_int64 s) 1)
+  in
+  like ~pp:I.pp ~equal:I.equal ~compare:I.compare
+    (map int64 I.of_int64 I.to_int64)
+  |> Attribute.set_random random
+
 let ref : type a. a t -> a ref t = fun a -> map a ref (fun t -> !t)
 let lazy_t : type a. a t -> a Lazy.t t = fun a -> map a Lazy.from_val Lazy.force
 

--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -28,6 +28,10 @@ module type DSL = sig
   val int32 : int32 t
   (** [int32] is a representation of the 32-bit integer type. *)
 
+  val int63 : Optint.Int63.t t
+  (** [int63] is a representation of the 63-bit integer type supplied by the
+      {!Optint} library. *)
+
   val int64 : int64 t
   (** [int64] is a representation of the 64-bit integer type. *)
 

--- a/test/ppx_repr/deriver/passing/basic.expected
+++ b/test/ppx_repr/deriver/passing/basic.expected
@@ -1,3 +1,4 @@
+type int63 = Optint.Int63.t
 module type BASIC  =
   sig
     val test_unit_t : unit Repr.t
@@ -5,6 +6,7 @@ module type BASIC  =
     val test_char_t : char Repr.t
     val test_int_t : int Repr.t
     val test_int32_t : int32 Repr.t
+    val test_int63_t : int63 Repr.t
     val test_int64_t : int64 Repr.t
     val test_float_t : float Repr.t
     val test_string_t : string Repr.t
@@ -26,6 +28,9 @@ module Basic : BASIC =
     [@@merlin.hide ]
     type test_int32 = int32[@@deriving repr]
     include struct let test_int32_t = Repr.int32 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int63 = int63[@@deriving repr]
+    include struct let test_int63_t = Repr.int63 end[@@ocaml.doc "@inline"]
     [@@merlin.hide ]
     type test_int64 = int64[@@deriving repr]
     include struct let test_int64_t = Repr.int64 end[@@ocaml.doc "@inline"]
@@ -109,6 +114,9 @@ module Inside_modules :
     [@@merlin.hide ]
     type test_int32 = Int32.t[@@deriving repr]
     include struct let test_int32_t = Repr.int32 end[@@ocaml.doc "@inline"]
+    [@@merlin.hide ]
+    type test_int63 = Optint.Int63.t[@@deriving repr]
+    include struct let test_int63_t = Repr.int63 end[@@ocaml.doc "@inline"]
     [@@merlin.hide ]
     type test_int64 = Int64.t[@@deriving repr]
     include struct let test_int64_t = Repr.int64 end[@@ocaml.doc "@inline"]

--- a/test/ppx_repr/deriver/passing/basic.ml
+++ b/test/ppx_repr/deriver/passing/basic.ml
@@ -1,9 +1,12 @@
+type int63 = Optint.Int63.t
+
 module type BASIC = sig
   val test_unit_t : unit Repr.t
   val test_bool_t : bool Repr.t
   val test_char_t : char Repr.t
   val test_int_t : int Repr.t
   val test_int32_t : int32 Repr.t
+  val test_int63_t : int63 Repr.t
   val test_int64_t : int64 Repr.t
   val test_float_t : float Repr.t
   val test_string_t : string Repr.t
@@ -16,6 +19,7 @@ module Basic : BASIC = struct
   type test_char = char [@@deriving repr]
   type test_int = int [@@deriving repr]
   type test_int32 = int32 [@@deriving repr]
+  type test_int63 = int63 [@@deriving repr]
   type test_int64 = int64 [@@deriving repr]
   type test_float = float [@@deriving repr]
   type test_string = string [@@deriving repr]
@@ -62,6 +66,7 @@ end = struct
   type test_char = Char.t [@@deriving repr]
   type test_int = Int.t [@@deriving repr]
   type test_int32 = Int32.t [@@deriving repr]
+  type test_int63 = Optint.Int63.t [@@deriving repr]
   type test_int64 = Int64.t [@@deriving repr]
   type test_float = Float.t [@@deriving repr]
   type test_string = String.t [@@deriving repr]

--- a/test/repr/dune
+++ b/test/repr/dune
@@ -6,6 +6,6 @@
  ; stanza. This cycle cannot be resolved by adding a [post] flag.
  ; See https://github.com/ocaml/opam/issues/4267.
  (package ppx_repr)
- (libraries alcotest repr hex)
+ (libraries alcotest repr hex optint)
  (preprocess
   (pps ppx_repr)))

--- a/test/repr/main.ml
+++ b/test/repr/main.ml
@@ -314,6 +314,7 @@ let test_to_string () =
   test "char" T.char 'a' "a";
   test "int" T.int (-100) "-100";
   test "int32" T.int32 Int32.max_int "2147483647";
+  test "int63" T.int63 Optint.Int63.max_int "4611686018427387903";
   test "int64" T.int64 Int64.max_int "9223372036854775807";
   test "float" T.float (-1.5) "-1.5";
   test "float{NaN}" T.float Stdlib.nan "\"nan\"";
@@ -391,6 +392,7 @@ let test_pp_dump () =
   test "char" T.char 'a' "'a'";
   test "int" T.int (-100) "-100";
   test "int32" T.int32 Int32.max_int "2147483647";
+  test "int63" T.int63 Optint.Int63.max_int "4611686018427387903";
   test "int64" T.int64 Int64.max_int "9223372036854775807";
   test "float" T.float (-1.5) "-1.5";
   test "float{NaN}" T.float Stdlib.nan "nan";
@@ -600,7 +602,7 @@ let test_random () =
       "Random generator should be deterministic given common PRNG state" v1 v2
   in
   test ~__POS__ [%typ: unit * bool * char];
-  test ~__POS__ [%typ: int * int32 * int64];
+  test ~__POS__ [%typ: int * int32 * (int63 * int64)];
   test ~__POS__ [%typ: float * string * bytes];
   test ~__POS__ [%typ: int option list];
   test ~__POS__ [%typ: (bool, string) result array];

--- a/test/repr/test_size_of.ml
+++ b/test/repr/test_size_of.ml
@@ -78,6 +78,7 @@ let test_primitive () =
   check_static ~__POS__ T.bool 1 true;
   check_static ~__POS__ T.char 1 ' ';
   check_static ~__POS__ T.int32 4 1l;
+  check_static ~__POS__ T.int63 8 Optint.Int63.zero;
   check_static ~__POS__ T.int64 8 (-1L);
   check_static ~__POS__ T.float 8 Float.nan
 


### PR DESCRIPTION
Fix https://github.com/mirage/repr/issues/78.

Depends on https://github.com/mirage/repr/pull/79 to get the tests working.