### PR TITLE
Fix some Odoc errors

### DIFF
--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -134,7 +134,7 @@ module type DSL = sig
   type empty = |
 
   val empty : empty t
-  (** [empty] is a representation of the {!empty} type. *)
+  (** [empty] is a representation of the {!type-empty} type. *)
 
   (** {1:records Records} *)
 
@@ -461,7 +461,7 @@ module type DSL = sig
 
   val pp_json : ?minify:bool -> 'a t -> 'a Fmt.t
   (** Similar to {!dump} but pretty-prints the JSON representation instead of
-      the OCaml one. See {!encode_json} for details about the encoding.
+      the OCaml one. See {!val-encode_json} for details about the encoding.
 
       For instance:
 
@@ -515,14 +515,14 @@ module type DSL = sig
 
   val decode_json_lexemes :
     'a t -> Jsonm.lexeme list -> ('a, [ `Msg of string ]) result
-  (** [decode_json_lexemes] is similar to {!decode_json} but uses an already
+  (** [decode_json_lexemes] is similar to {!val-decode_json} but uses an already
       decoded list of JSON lexemes instead of a decoder. *)
 
   val to_json_string : ?minify:bool -> 'a t -> 'a -> string
-  (** [to_json_string] is {!encode_json} with a string encoder. *)
+  (** [to_json_string] is {!val-encode_json} with a string encoder. *)
 
   val of_json_string : 'a t -> string -> ('a, [ `Msg of string ]) result
-  (** [of_json_string] is {!decode_json} with a string decoder .*)
+  (** [of_json_string] is {!val-decode_json} with a string decoder .*)
 
   (** {2 Binary Converters} *)
 
@@ -553,11 +553,11 @@ module type DSL = sig
   (** [decode_bin t] is the binary decoder for values of type [t]. *)
 
   val to_bin_string : 'a t -> ('a -> string) staged
-  (** [to_bin_string t x] use {!encode_bin} to convert [x], of type [t], to a
-      string.
+  (** [to_bin_string t x] use {!val-encode_bin} to convert [x], of type [t], to
+      a string.
 
       {b NOTE:} When [t] is {!Type.string} or {!Type.bytes}, the original buffer
-      [x] is not prefixed by its size as {!encode_bin} would do. If [t] is
+      [x] is not prefixed by its size as {!val-encode_bin} would do. If [t] is
       {!Type.string}, the result is [x] (without copy). *)
 
   val of_bin_string : 'a t -> (string -> ('a, [ `Msg of string ]) result) staged
@@ -621,13 +621,13 @@ module type DSL = sig
         operation, they automatically fall-back to their boxed counter-part. *)
 
     val encode_bin : 'a t -> 'a encode_bin staged
-    (** Same as {!encode_bin} for unboxed values. *)
+    (** Same as {!val-encode_bin} for unboxed values. *)
 
     val decode_bin : 'a t -> 'a decode_bin staged
-    (** Same as {!decode_bin} for unboxed values. *)
+    (** Same as {!val-decode_bin} for unboxed values. *)
 
     val size_of : 'a t -> 'a size_of
-    (** Same as {!size_of} for unboxed values. *)
+    (** Same as {!val-size_of} for unboxed values. *)
   end
 
   (** {1 Abstract types} *)


### PR DESCRIPTION
Fix some of the documentation errors currently failing our CI. I'm not sure what to make of the remaining ones, which complain about ambiguous references (that I think are not actually ambiguous):

```
File "src/repr/type_intf.ml", line 48, characters 11-20:
Reference to 'string' is ambiguous. Please specify its kind: val-string, val-string, val-string, val-string.
File "src/repr/type_intf.ml", line 51, characters 11-19:
Reference to 'bytes' is ambiguous. Please specify its kind: val-bytes, val-bytes, val-bytes, val-bytes.
File "src/repr/type_intf.ml", line 56, characters 6-16:
Reference to 'Unboxed' is ambiguous. Please specify its kind: module-Unboxed, module-Unboxed, module-Unboxed, module-Unboxed.
File "src/repr/type_intf.ml", line 107, characters 17-26:
Reference to 'Of_set' is ambiguous. Please specify its kind: module-Of_set, module-Of_set, module-Of_set, module-Of_set.
File "src/repr/type_intf.ml", line 137, characters 41-54:
Reference to 'empty' is ambiguous. Please specify its kind: type-empty, type-empty, type-empty, type-empty.
File "src/repr/type_intf.ml", line 144, characters 6-13:
Reference to '(|+)' is ambiguous. Please specify its kind: val-(|+), val-(|+), val-(|+), val-(|+).
File "src/repr/type_intf.ml", line 145, characters 6-23:
Reference to 'sealr' is ambiguous. Please specify its kind: val-sealr, val-sealr, val-sealr, val-sealr.
File "src/repr/type_intf.ml", line 150, characters 11-18:
Reference to '(|+)' is ambiguous. Please specify its kind: val-(|+), val-(|+), val-(|+), val-(|+).
File "src/repr/type_intf.ml", line 150, characters 49-57:
Reference to 'sealr' is ambiguous. Please specify its kind: val-sealr, val-sealr, val-sealr, val-sealr.
File "src/repr/type_intf.ml", line 199, characters 16-23:
Reference to '(|~)' is ambiguous. Please specify its kind: val-(|~), val-(|~), val-(|~), val-(|~).
File "src/repr/type_intf.ml", line 200, characters 17-34:
Reference to 'sealv' is ambiguous. Please specify its kind: val-sealv, val-sealv, val-sealv, val-sealv.
File "src/repr/type_intf.ml", line 205, characters 37-44:
Reference to '(|~)' is ambiguous. Please specify its kind: val-(|~), val-(|~), val-(|~), val-(|~).
File "src/repr/type_intf.ml", line 206, characters 6-14:
Reference to 'sealv' is ambiguous. Please specify its kind: val-sealv, val-sealv, val-sealv, val-sealv.
File "src/repr/type_intf.ml", line 353, characters 13-45:
Reference to 'generics' is ambiguous. Please specify its kind: section-generics, section-generics, section-generics, section-generics.
File "src/repr/type_intf.ml", line 400, characters 46-50:
Reference to 't' is ambiguous. Please specify its kind: type-t, type-t, type-t, type-t.
File "src/repr/type_intf.ml", line 419, characters 37-46:
Reference to 'random' is ambiguous. Please specify its kind: val-random, val-random, val-random, val-random.
File "src/repr/type_intf.ml", line 464, characters 25-43:
Reference to 'encode_json' is ambiguous. Please specify its kind: val-encode_json, val-encode_json, val-encode_json, val-encode_json.
File "src/repr/type_intf.ml", line 504, characters 34-42:
Reference to 'case0' is ambiguous. Please specify its kind: val-case0, val-case0, val-case0, val-case0.
File "src/repr/type_intf.ml", line 505, characters 34-42:
Reference to 'case1' is ambiguous. Please specify its kind: val-case1, val-case1, val-case1, val-case1.
... etc.
```

CC @Julow, any idea what's going on here?