### PR TITLE
Fix the CI changelog check to refer to the right base branch

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -2,7 +2,7 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:


### PR DESCRIPTION
This was broken during the extraction of `mirage/repr` from `mirage/irmin`, since this repository has never used `master` as its main branch.