### PR TITLE
ppx_repr: inline `name_type_params_in_td` implementation

### DIFF
--- a/test/ppx_repr/deriver/passing/type_params.expected
+++ b/test/ppx_repr/deriver/passing/type_params.expected
@@ -13,8 +13,8 @@ let __ : type a. a typ -> a Id.t typ = Id.t
 module Phantom :
   sig
     type _ t = int[@@deriving repr]
-    include sig val t : 'v_x__001_ Repr.t -> 'v_x__001_ t Repr.t end[@@ocaml.doc
-                                                                    "@inline"]
+    include sig val t : 'a__001_ Repr.t -> 'a__001_ t Repr.t end[@@ocaml.doc
+                                                                  "@inline"]
     [@@merlin.hide ]
   end =
   struct


### PR DESCRIPTION
This avoids the results of the snapshot tests varying according to whether `ppxlib.0.23.0` or `ppxlib.0.24.0` is used (so that we don't need to conflict on one or the other).