### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 0.6.0 (2022-01-04)
 
 - Change the type of `Repr.decode_bin` to take a mutable buffer offset rather
   than threading an immutable position. (#81, @CraigFe)


### PR DESCRIPTION
Corresponding `opam-repository` PR: https://github.com/ocaml/opam-repository/pull/20414.