### PR TITLE
fix equality on float with nan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- Change `Repr.Equal.float` to use `Float.equal` rather than polymorphic equality. (#96, @n-osborne)
+
 ### 0.6.0 (2022-01-04)
 
 - Change the type of `Repr.decode_bin` to take a mutable buffer offset rather

--- a/src/repr/type_ordered.ml
+++ b/src/repr/type_ordered.ml
@@ -91,9 +91,7 @@ module Equal = struct
   let int64 (x : int64) (y : int64) = x = y
   let string x y = x == y || String.equal x y
   let bytes x y = x == y || Bytes.equal x y
-
-  (* NOTE: equality is ill-defined on float *)
-  let float (x : float) (y : float) = x = y
+  let float x y = Float.equal x y
 
   let list e =
     let e = unstage e in


### PR DESCRIPTION
As `nan <> nan` w.r.t polymorphic equality, we use `Float.equal` instead.