### PR TITLE
Update exception formatting in tests

### DIFF
--- a/test/ppx_repr/deriver/errors/recursion_more_than_two.expected
+++ b/test/ppx_repr/deriver/errors/recursion_more_than_two.expected
@@ -1,1 +1,1 @@
-Fatal error: exception (Failure "Mutually-recursive groups of size > 2 supported")
+Fatal error: exception Failure("Mutually-recursive groups of size > 2 supported")

--- a/test/ppx_repr/deriver/errors/recursion_with_type_parameters.expected
+++ b/test/ppx_repr/deriver/errors/recursion_with_type_parameters.expected
@@ -1,1 +1,1 @@
-Fatal error: exception (Failure "Can't support mutually-recursive types with type parameters")
+Fatal error: exception Failure("Can't support mutually-recursive types with type parameters")


### PR DESCRIPTION
This PR fixes the formatting for exceptions, which has changed somewhere and is causing the tests to fail.