### PR TITLE
Expose Jsonm decoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+ - Expose the underlying `Jsonm.decoder` for custom JSON serialisation in
+   functions like `Repr.like`. (#103, @patricoferris)
+
 ### 0.6.0 (2022-01-04)
 
 - Change the type of `Repr.decode_bin` to take a mutable buffer offset rather

--- a/src/repr/type_core.ml
+++ b/src/repr/type_core.ml
@@ -31,6 +31,8 @@ module Json = struct
         e.lexemes <- t;
         `Lexeme h
     | [] -> Jsonm.decode e.d
+
+  let decoder_and_lexemes t = (t.d, t.lexemes)
 end
 
 module Encode_json = Attribute.Make1 (struct

--- a/src/repr/type_core_intf.ml
+++ b/src/repr/type_core_intf.ml
@@ -190,5 +190,7 @@ module type Type_core = sig
     val decode :
       json_decoder ->
       [> `Await | `End | `Error of Jsonm.error | `Lexeme of Jsonm.lexeme ]
+
+    val decoder_and_lexemes : decoder -> Jsonm.decoder * Jsonm.lexeme list
   end
 end

--- a/src/repr/type_intf.ml
+++ b/src/repr/type_intf.ml
@@ -446,6 +446,11 @@ module type DSL = sig
     (** [rewind d l] rewinds [l] on top of the current state of [d]. This allows
         to put back lexemes already seen. *)
 
+    val decoder_and_lexemes : decoder -> Jsonm.decoder * Jsonm.lexeme list
+    (** [decoder_and_lexemes d] returns the underlying {!Jsonm.decoder} and a
+        list of lexemes you may have rewound. If you have not called {!rewind}
+        the list will be empty. *)
+
     val assoc : 'a t -> (string * 'a) list t
     (** [assoc v] is the typerepr of an association list (assoc) in which keys
         are strings and values are of typerepr [v]. The JSON codec represents


### PR DESCRIPTION
Not sure if this should expose the rewound lexemes, but a user might want to assert that it is empty. At any rate, if a user wants to provide their own custom JSON functions at the moment they must use the API presented by the `Json` module and call `decode` whereas in the encoding API they have direct access to the `Jsonm.encoder` which means they have direct access to the destination too. With this change I can have access to the source and destination so I can use:

```ocaml
let json =
  let enc e v =
    let dst = Jsonm.encoder_dst e in
    match dst with
    | `Buffer buffer -> Types_j.write_t1 buffer v
    | `Channel oc ->
      let buff = Buffer.create 128 in
      Types_j.write_t1 buff v;
      Buffer.output_buffer oc buff
    | _ -> failwith "Manual dst unsupported"
  in
  let dec d =
    let src = Irmin.Type.Json.jsonm_decoder d |> Jsonm.decoder_src in
    match src with
    | `String s -> wrap_exn Types_j.t1_of_string s
    | `Channel ic ->
      let lexbuf = Lexing.from_channel ic in
      let state = Yojson.init_lexer () in
      wrap_exn (Types_j.read_t1 state) lexbuf
    | `Manual -> Error (`Msg "Manual src not supported")
  in
  enc, dec
in
```

In this example `Types_j` are `Yojson`-based functions derived via atdgen, which I can pass to `Repr.like`. [See this gist](https://gist.github.com/patricoferris/d64e8dc4c6e80a58bb6a0b301f47735e). 