### PR TITLE
5.2 ast bump

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.0
+version = 0.26.2
 profile = conventional
 
 ocaml-version = 4.08.0

--- a/fuzz/rewriter/main.ml
+++ b/fuzz/rewriter/main.ml
@@ -143,7 +143,8 @@ module Located (A : Ast_builder.S) : S = struct
         [%e
           cases
             [%expr
-              T.variant variant_name [%e wrap_params (pexp_function_cases destructor)]]]
+              T.variant variant_name
+                [%e wrap_params (pexp_function_cases destructor)]]]
         |> T.sealv]
     in
     case ~lhs:pattern ~guard:None ~rhs

--- a/fuzz/rewriter/main.ml
+++ b/fuzz/rewriter/main.ml
@@ -143,7 +143,7 @@ module Located (A : Ast_builder.S) : S = struct
         [%e
           cases
             [%expr
-              T.variant variant_name [%e wrap_params (pexp_function destructor)]]]
+              T.variant variant_name [%e wrap_params (pexp_function_cases destructor)]]]
         |> T.sealv]
     in
     case ~lhs:pattern ~guard:None ~rhs

--- a/src/ppx_repr/lib/algebraic.ml
+++ b/src/ppx_repr/lib/algebraic.ml
@@ -133,7 +133,7 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
       in
       variant_pattern c.pcd_name.txt pattern n
     in
-    cs >|= pattern_of_cdecl |> pexp_function |> lambda (cs >|= fparam_of_cdecl)
+    cs >|= pattern_of_cdecl |> pexp_function_cases |> lambda (cs >|= fparam_of_cdecl)
 
   (** Analogous to {!variant_composite} but using AST fragments for polymorphic
       variants. *)
@@ -153,7 +153,7 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
     in
     fs
     >|= pattern_case_of_rowfield
-    |> pexp_function
+    |> pexp_function_cases
     |> lambda (fs >|= fparam_of_rowfield)
 
   (** {1 Functional encodings of composite types}

--- a/src/ppx_repr/lib/algebraic.ml
+++ b/src/ppx_repr/lib/algebraic.ml
@@ -47,13 +47,13 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
     if polymorphic then pexp_variant name body
     else pexp_construct (Located.lident name) body
 
-  (** {[ |~ case0 "cons_name" (`)Cons_name ]} *)
+  (** {[
+        |~ case0 "cons_name" (`)Cons_name
+      ]} *)
   let variant_case0 ~lib ~polymorphic ~cons_name e =
     [%expr
-      [%e dsl ~lib `add_case]
-        [%e e]
-        ([%e dsl ~lib `case0]
-           [%e estring cons_name]
+      [%e dsl ~lib `add_case] [%e e]
+        ([%e dsl ~lib `case0] [%e estring cons_name]
            [%e construct ~polymorphic cons_name])]
 
   (** {[
@@ -63,8 +63,7 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
     let tuple_pat = idents >|= pvar |> ppat_tuple in
     let tuple_exp = idents >|= evar |> pexp_tuple in
     [%expr
-      [%e dsl ~lib `add_case]
-        [%e e]
+      [%e dsl ~lib `add_case] [%e e]
         ([%e dsl ~lib `case1] [%e estring cons_name] [%e component_type]
            (fun [%p tuple_pat] ->
              [%e construct ~polymorphic ~body:tuple_exp cons_name]))]
@@ -80,14 +79,15 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
   (** [|+ field "field_name" (field_type) (fun t -> t.field_name)] *)
   let record_field ~lib { field_name; field_repr } e =
     [%expr
-      [%e dsl ~lib `add_field]
-        [%e e]
+      [%e dsl ~lib `add_field] [%e e]
         ([%e dsl ~lib `field] [%e estring field_name] [%e field_repr] (fun t ->
              [%e pexp_field (evar "t") (Located.lident field_name)]))]
 
   (** Record composites are encoded as a constructor function
 
-      {[ fun field1 field2 ... fieldN -> { field1; field2; ...; fieldN }) ]} *)
+      {[
+        fun field1 field2 ... fieldN -> { field1; field2; ...; fieldN })
+      ]} *)
   let record_composite fields =
     let fields = fields >|= fun l -> l.pld_name.txt in
     let record =
@@ -96,7 +96,9 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
     in
     lambda fields record
 
-  (** {[ | Cons_name (x1, x2, x3) -> cons_name x1 x2 x3 ] ]} *)
+  (** {[
+        | Cons_name (x1, x2, x3) -> cons_name x1 x2 x3 ]
+      ]} *)
   let variant_pattern cons_name pattern n =
     let fparam_of_name name = String.lowercase_ascii name in
     match n with
@@ -133,7 +135,10 @@ module Located (A : Ast_builder.S) (M : Monad.S) : S with module M = M = struct
       in
       variant_pattern c.pcd_name.txt pattern n
     in
-    cs >|= pattern_of_cdecl |> pexp_function_cases |> lambda (cs >|= fparam_of_cdecl)
+    cs
+    >|= pattern_of_cdecl
+    |> pexp_function_cases
+    |> lambda (cs >|= fparam_of_cdecl)
 
   (** Analogous to {!variant_composite} but using AST fragments for polymorphic
       variants. *)

--- a/src/ppx_repr/lib/engine.ml
+++ b/src/ppx_repr/lib/engine.ml
@@ -118,12 +118,12 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
     | Ptyp_package _ -> Raise.Unsupported.type_package ~loc typ
     | Ptyp_extension _ -> Raise.Unsupported.type_extension ~loc typ
     | Ptyp_alias (c, var) ->
-        if contains_tvar var c then (
-          add_var_repr var_repr (`Var var, evar var);
+        if contains_tvar var.txt c then (
+          add_var_repr var_repr (`Var var.txt, evar var.txt);
           let+ inner = derive_core c in
-          recursive ~lib var inner)
+          recursive ~lib var.txt inner)
         else derive_core c
-    | Ptyp_object _ | Ptyp_class _ -> invalid_arg "unsupported"
+    | Ptyp_object _ | Ptyp_class _ | Ptyp_open _ -> invalid_arg "unsupported"
 
   and derive_tuple args =
     let* { lib; _ } = ask in
@@ -277,11 +277,11 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
            | Ptyp_alias (c, v) ->
                (* Push [v] to the bound stack, traverse the alias, then remove it. *)
                let c, acc =
-                 super#core_type c { acc with ctx_bound = v :: acc.ctx_bound }
+                 super#core_type c { acc with ctx_bound = v.txt :: acc.ctx_bound }
                in
                let ctx_bound =
                  match acc.ctx_bound with
-                 | v' :: ctx_bound when v = v' -> ctx_bound
+                 | v' :: ctx_bound when v.txt = v' -> ctx_bound
                  | _ -> assert false
                in
                (Ptyp_alias (c, v), { acc with ctx_bound })

--- a/src/ppx_repr/lib/engine.ml
+++ b/src/ppx_repr/lib/engine.ml
@@ -277,7 +277,8 @@ module Located (Attributes : Attributes.S) (A : Ast_builder.S) : S = struct
            | Ptyp_alias (c, v) ->
                (* Push [v] to the bound stack, traverse the alias, then remove it. *)
                let c, acc =
-                 super#core_type c { acc with ctx_bound = v.txt :: acc.ctx_bound }
+                 super#core_type c
+                   { acc with ctx_bound = v.txt :: acc.ctx_bound }
                in
                let ctx_bound =
                  match acc.ctx_bound with

--- a/src/ppx_repr/lib/meta_deriving.ml
+++ b/src/ppx_repr/lib/meta_deriving.ml
@@ -102,7 +102,7 @@ module Args = struct
 end
 
 (** Each plugin gets a flag in the main deriver corresponding to whether it's
-    activated or not. For instance, [\[@@deriving repr ~equal\]] indicates that
+    activated or not. For instance, [[@@deriving repr ~equal]] indicates that
     the "equal" plugin should be run on this type definition.
 
     Given the list of plugins [ p1; p2; ... pn ], we need to build:

--- a/src/ppx_repr/lib/utils.ml
+++ b/src/ppx_repr/lib/utils.ml
@@ -44,10 +44,10 @@ module Make (A : Ast_builder.S) : sig
   (** Left-to-right composition of a list of functions. *)
 
   val lambda : string list -> expression -> expression
-  (** [lambda \[ "x_1"; ...; "x_n" \] e] is [fun x1 ... x_n -> e] *)
+  (** [lambda [ "x_1"; ...; "x_n" ] e] is [fun x1 ... x_n -> e] *)
 
   val arrow : core_type list -> core_type -> core_type
-  (** [arrow \[ "t_1"; ...; "t_n" \] u] is [t_1 -> ... -> t_n -> u] *)
+  (** [arrow [ "t_1"; ...; "t_n" ] u] is [t_1 -> ... -> t_n -> u] *)
 end = struct
   open A
 

--- a/src/repr/binary.ml
+++ b/src/repr/binary.ml
@@ -29,7 +29,7 @@ module Char = struct
     let pos = !pos_ref in
     pos_ref := pos + 1;
     buf.[pos]
-    [@@inline always]
+  [@@inline always]
 
   let sizer = Sizer.static 1
 end
@@ -47,7 +47,7 @@ module Int8 = struct
   let encode i k = k (charstring_of_code i)
 
   let decode buf pos_ref = Stdlib.Char.code (Char.decode buf pos_ref)
-    [@@inline always]
+  [@@inline always]
 end
 
 module Int16 = struct

--- a/src/repr/size.ml
+++ b/src/repr/size.ml
@@ -33,9 +33,9 @@ module Sizer = struct
       - [of_value]: given a value to encode, return the size of its encoding.
 
       - [of_encoding]: given a buffer [buf] and an offset [off], return the
-        _offset_ immediately _after_ the encoding starting at [buf.\[off\]]
-        NOTE: not the length of the encoding itself, to enable chains of such
-        sizers to call each other in tail-position.
+        _offset_ immediately _after_ the encoding starting at [buf.[off]] NOTE:
+        not the length of the encoding itself, to enable chains of such sizers
+        to call each other in tail-position.
 
       Invariant: [∀ n. (of_value = Static n) ⟺ (of_encoding = Static n)]. *)
 

--- a/src/repr/type_ordered.ml
+++ b/src/repr/type_ordered.ml
@@ -301,7 +301,7 @@ module Compare = struct
     | Float -> stage float
     | String _ -> stage string
     | Bytes _ -> stage bytes
-    [@@inline always]
+  [@@inline always]
 
   let rec t : type a. a t -> a compare staged = function
     | Self s -> self s

--- a/test/ppx_repr/deriver/gen_dune_rules.ml
+++ b/test/ppx_repr/deriver/gen_dune_rules.ml
@@ -30,13 +30,13 @@ let output_stanzas ~expect_failure filename =
     let pp_action ppf expect_failure =
       Format.fprintf ppf
         (if expect_failure then
-         "; expect the process to fail, capturing stderr@,\
-          @[<v 1>(with-stderr-to@,\
-          %%{targets}@,\
-          (bash \"! ./%%{pp} -no-color --impl %%{input}\"))@]"
-        else
-          "(run ./%%{pp} -deriving-keep-w32 both --impl %%{input} -o \
-           %%{targets})")
+           "; expect the process to fail, capturing stderr@,\
+            @[<v 1>(with-stderr-to@,\
+            %%{targets}@,\
+            (bash \"! ./%%{pp} -no-color --impl %%{input}\"))@]"
+         else
+           "(run ./%%{pp} -deriving-keep-w32 both --impl %%{input} -o \
+            %%{targets})")
     in
     Format.fprintf ppf
       "; Run the PPX on the `.ml` file@,\

--- a/test/ppx_repr/deriver/passing/arguments.expected
+++ b/test/ppx_repr/deriver/passing/arguments.expected
@@ -23,9 +23,8 @@ include
         (Repr.(|~)
            (Repr.(|~)
               (Repr.variant "point_elsewhere3"
-                 (fun a ->
-                    fun b ->
-                      function | A (x1, x2) -> a (x1, x2) | B x1 -> b x1))
+                 (fun a b ->
+                    function | A (x1, x2) -> a (x1, x2) | B x1 -> b x1))
               (Repr.case1 "A" (Repr.pair Repr.int c_wit)
                  (fun (x1, x2) -> A (x1, x2))))
            (Repr.case1 "B" c_wit (fun x1 -> B x1)))
@@ -45,10 +44,8 @@ include
               (Repr.(|+)
                  (Repr.(|+)
                     (Repr.record "point_elsewhere4"
-                       (fun lorem ->
-                          fun ipsum ->
-                            fun dolor ->
-                              fun sit -> { lorem; ipsum; dolor; sit }))
+                       (fun lorem ipsum dolor sit ->
+                          { lorem; ipsum; dolor; sit }))
                     (Repr.field "lorem" Repr.string (fun t -> t.lorem)))
                  (Repr.field "ipsum" c_wit (fun t -> t.ipsum)))
               (Repr.field "dolor" Repr.int (fun t -> t.dolor)))

--- a/test/ppx_repr/deriver/passing/as_alias.expected
+++ b/test/ppx_repr/deriver/passing/as_alias.expected
@@ -29,11 +29,10 @@ module Recursive :
                  (Repr.(|~)
                     (Repr.(|~)
                        (Repr.variant "tree"
-                          (fun branch ->
-                             fun leaf ->
-                               function
-                               | `Branch x1 -> branch x1
-                               | `Leaf x1 -> leaf x1))
+                          (fun branch leaf ->
+                             function
+                             | `Branch x1 -> branch x1
+                             | `Leaf x1 -> leaf x1))
                        (Repr.case1 "Branch" (Repr.triple tree Repr.int tree)
                           (fun x1 -> `Branch x1)))
                     (Repr.case1 "Leaf" a (fun x1 -> `Leaf x1))))

--- a/test/ppx_repr/deriver/passing/extension.expected
+++ b/test/ppx_repr/deriver/passing/extension.expected
@@ -15,17 +15,14 @@ module Sum =
         (Repr.(|~)
            (Repr.(|~)
               (Repr.variant "t"
-                 (fun foo ->
-                    fun bar -> function | `Foo -> foo | `Bar x1 -> bar x1))
+                 (fun foo bar -> function | `Foo -> foo | `Bar x1 -> bar x1))
               (Repr.case0 "Foo" `Foo))
            (Repr.case1 "Bar" Repr.string (fun x1 -> `Bar x1)))
   end
 module Params =
   struct
-    let __ : type a. a typ -> a list typ = fun a -> Repr.list a
-    let __ : type a b. a typ -> b typ -> (a * b * a) typ =
-      fun a -> fun _x__001_ -> Repr.triple a _x__001_ a
-    let __ : type a b. a typ -> b typ -> (a, b) result typ =
-      fun _x__002_ -> fun _x__003_ -> Repr.result _x__002_ _x__003_
+    let __ a = Repr.list a
+    let __ a _x__001_ = Repr.triple a _x__001_ a
+    let __ _x__002_ _x__003_ = Repr.result _x__002_ _x__003_
   end
 module Namespace = struct let (_ : string typ) = Repr.string end

--- a/test/ppx_repr/deriver/passing/polyvariant.expected
+++ b/test/ppx_repr/deriver/passing/polyvariant.expected
@@ -6,8 +6,7 @@ include
         (Repr.(|~)
            (Repr.(|~)
               (Repr.variant "test_polyvar1"
-                 (fun on ->
-                    fun off -> function | `On x1 -> on x1 | `Off -> off))
+                 (fun on off -> function | `On x1 -> on x1 | `Off -> off))
               (Repr.case1 "On" Repr.int (fun x1 -> `On x1)))
            (Repr.case0 "Off" `Off))
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -22,23 +21,20 @@ include
            (Repr.(|~)
               (Repr.(|~)
                  (Repr.variant "test_polyvar2"
-                    (fun outer_a ->
-                       fun outer_b ->
-                         fun outer_c ->
-                           function
-                           | `Outer_a x1 -> outer_a x1
-                           | `Outer_b x1 -> outer_b x1
-                           | `Outer_c x1 -> outer_c x1))
+                    (fun outer_a outer_b outer_c ->
+                       function
+                       | `Outer_a x1 -> outer_a x1
+                       | `Outer_b x1 -> outer_b x1
+                       | `Outer_c x1 -> outer_c x1))
                  (Repr.case1 "Outer_a"
                     (Repr.sealv
                        (Repr.(|~)
                           (Repr.(|~)
                              (Repr.variant "test_polyvar2"
-                                (fun inner_a ->
-                                   fun inner_b ->
-                                     function
-                                     | `Inner_a -> inner_a
-                                     | `Inner_b -> inner_b))
+                                (fun inner_a inner_b ->
+                                   function
+                                   | `Inner_a -> inner_a
+                                   | `Inner_b -> inner_b))
                              (Repr.case0 "Inner_a" `Inner_a))
                           (Repr.case0 "Inner_b" `Inner_b)))
                     (fun x1 -> `Outer_a x1)))
@@ -54,11 +50,10 @@ include
                  (Repr.(|~)
                     (Repr.(|~)
                        (Repr.variant "test_polyvar2"
-                          (fun inner_a ->
-                             fun inner_c ->
-                               function
-                               | `Inner_a x1 -> inner_a x1
-                               | `Inner_c x1 -> inner_c x1))
+                          (fun inner_a inner_c ->
+                             function
+                             | `Inner_a x1 -> inner_a x1
+                             | `Inner_c x1 -> inner_c x1))
                        (Repr.case1 "Inner_a" Repr.string
                           (fun x1 -> `Inner_a x1)))
                     (Repr.case1 "Inner_c" Repr.int (fun x1 -> `Inner_c x1))))
@@ -76,11 +71,10 @@ include
              (Repr.(|~)
                 (Repr.(|~)
                    (Repr.variant "test_polyvar3"
-                      (fun branch ->
-                         fun leaf ->
-                           function
-                           | `Branch x1 -> branch x1
-                           | `Leaf x1 -> leaf x1))
+                      (fun branch leaf ->
+                         function
+                         | `Branch x1 -> branch x1
+                         | `Leaf x1 -> leaf x1))
                    (Repr.case1 "Branch"
                       (Repr.pair test_polyvar3_t test_polyvar3_t)
                       (fun x1 -> `Branch x1)))

--- a/test/ppx_repr/deriver/passing/record.expected
+++ b/test/ppx_repr/deriver/passing/record.expected
@@ -10,8 +10,7 @@ include
            (Repr.(|+)
               (Repr.(|+)
                  (Repr.record "test_record1"
-                    (fun alpha ->
-                       fun beta -> fun gamma -> { alpha; beta; gamma }))
+                    (fun alpha beta gamma -> { alpha; beta; gamma }))
                  (Repr.field "alpha" Repr.string (fun t -> t.alpha)))
               (Repr.field "beta" (Repr.list Repr.int64) (fun t -> t.beta)))
            (Repr.field "gamma" Repr.unit (fun t -> t.gamma)))
@@ -27,9 +26,8 @@ include
         (Repr.(|+)
            (Repr.(|+)
               (Repr.record "test_record2"
-                 (fun the_FIRST_identifier ->
-                    fun the_SECOND_identifier ->
-                      { the_FIRST_identifier; the_SECOND_identifier }))
+                 (fun the_FIRST_identifier the_SECOND_identifier ->
+                    { the_FIRST_identifier; the_SECOND_identifier }))
               (Repr.field "the_FIRST_identifier" (Repr.option test_record1_t)
                  (fun t -> t.the_FIRST_identifier)))
            (Repr.field "the_SECOND_identifier"

--- a/test/ppx_repr/deriver/passing/recursive.expected
+++ b/test/ppx_repr/deriver/passing/recursive.expected
@@ -33,19 +33,18 @@ module Recursive_group :
       struct
         let (odd_t, even_t) =
           Repr.mu2
-            (fun odd_t ->
-               fun even_t ->
-                 ((Repr.sealv
-                     (Repr.(|~)
-                        (Repr.variant "odd"
-                           (fun odd -> function | Odd x1 -> odd x1))
-                        (Repr.case1 "Odd" (Repr.option even_t)
-                           (fun x1 -> Odd x1)))),
-                   (Repr.sealv
-                      (Repr.(|~)
-                         (Repr.variant "even"
-                            (fun even -> function | Even x1 -> even x1))
-                         (Repr.case1 "Even" (Repr.option odd_t)
-                            (fun x1 -> Even x1))))))
+            (fun odd_t even_t ->
+               ((Repr.sealv
+                   (Repr.(|~)
+                      (Repr.variant "odd"
+                         (fun odd -> function | Odd x1 -> odd x1))
+                      (Repr.case1 "Odd" (Repr.option even_t)
+                         (fun x1 -> Odd x1)))),
+                 (Repr.sealv
+                    (Repr.(|~)
+                       (Repr.variant "even"
+                          (fun even -> function | Even x1 -> even x1))
+                       (Repr.case1 "Even" (Repr.option odd_t)
+                          (fun x1 -> Even x1))))))
       end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end 

--- a/test/ppx_repr/deriver/passing/signature.expected
+++ b/test/ppx_repr/deriver/passing/signature.expected
@@ -39,13 +39,11 @@ module SigTests :
                (Repr.(|~)
                   (Repr.(|~)
                      (Repr.variant "my_variant"
-                        (fun a ->
-                           fun b ->
-                             fun c ->
-                               function
-                               | A x1 -> a x1
-                               | B x1 -> b x1
-                               | C (x1, x2) -> c (x1, x2)))
+                        (fun a b c ->
+                           function
+                           | A x1 -> a x1
+                           | B x1 -> b x1
+                           | C (x1, x2) -> c (x1, x2)))
                      (Repr.case1 "A" (Repr.result my_int_t Repr.int)
                         (fun x1 -> A x1)))
                   (Repr.case1 "B" Repr.unit (fun x1 -> B x1)))

--- a/test/ppx_repr/deriver/passing/type_params.expected
+++ b/test/ppx_repr/deriver/passing/type_params.expected
@@ -9,7 +9,7 @@ module Id :
     type 'a t = 'a[@@deriving repr]
     include struct let t a = a end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end 
-let __ : type a. a typ -> a Id.t typ = Id.t
+let __ = Id.t
 module Phantom :
   sig
     type _ t = int[@@deriving repr]
@@ -22,7 +22,7 @@ module Phantom :
     include struct let t _ = Repr.int end[@@ocaml.doc "@inline"][@@merlin.hide
                                                                   ]
   end 
-let __ : type a. a typ -> a Phantom.t typ = Phantom.t
+let __ = Phantom.t
 module Multiple :
   sig
     type ('a, 'b, 'c) t = {
@@ -46,12 +46,10 @@ module Multiple :
             (Repr.(|+)
                (Repr.(|+)
                   (Repr.(|+)
-                     (Repr.record "t"
-                        (fun foo -> fun bar -> fun baz -> { foo; bar; baz }))
+                     (Repr.record "t" (fun foo bar baz -> { foo; bar; baz }))
                      (Repr.field "foo" a (fun t -> t.foo)))
                   (Repr.field "bar" (Repr.list b) (fun t -> t.bar)))
                (Repr.field "baz" (Repr.pair b c) (fun t -> t.baz)))
       end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end 
-let __ : type a b c. a typ -> b typ -> c typ -> (a, b, c) Multiple.t typ =
-  Multiple.t
+let __ = Multiple.t

--- a/test/ppx_repr/deriver/passing/variant.expected
+++ b/test/ppx_repr/deriver/passing/variant.expected
@@ -43,9 +43,8 @@ include
            (Repr.(|~)
               (Repr.(|~)
                  (Repr.variant "test_variant4"
-                    (fun a4 ->
-                       fun b4 ->
-                         fun c4 -> function | A4 -> a4 | B4 -> b4 | C4 -> c4))
+                    (fun a4 b4 c4 ->
+                       function | A4 -> a4 | B4 -> b4 | C4 -> c4))
                  (Repr.case0 "A4" A4)) (Repr.case0 "B4" B4))
            (Repr.case0 "C4" C4))
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
@@ -61,13 +60,11 @@ include
            (Repr.(|~)
               (Repr.(|~)
                  (Repr.variant "test_variant5"
-                    (fun a5 ->
-                       fun b5 ->
-                         fun c5 ->
-                           function
-                           | A5 -> a5
-                           | B5 (x1, x2) -> b5 (x1, x2)
-                           | C5 (x1, x2, x3) -> c5 (x1, x2, x3)))
+                    (fun a5 b5 c5 ->
+                       function
+                       | A5 -> a5
+                       | B5 (x1, x2) -> b5 (x1, x2)
+                       | C5 (x1, x2, x3) -> c5 (x1, x2, x3)))
                  (Repr.case0 "A5" A5))
               (Repr.case1 "B5" (Repr.pair Repr.string test_variant4_t)
                  (fun (x1, x2) -> B5 (x1, x2))))
@@ -86,11 +83,10 @@ include
              (Repr.(|~)
                 (Repr.(|~)
                    (Repr.variant "test_variant6"
-                      (fun nil ->
-                         fun cons ->
-                           function
-                           | Nil -> nil
-                           | Cons (x1, x2) -> cons (x1, x2)))
+                      (fun nil cons ->
+                         function
+                         | Nil -> nil
+                         | Cons (x1, x2) -> cons (x1, x2)))
                    (Repr.case0 "Nil" Nil))
                 (Repr.case1 "Cons" (Repr.pair Repr.string test_variant6_t)
                    (fun (x1, x2) -> Cons (x1, x2)))))


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.



To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

Note: no update has been made of the `opam` file, but `ppxlib` will likely need a lower-bound before merging/releasing.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses.