### PR TITLE
Add x-maintenance-intent entries

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,5 @@
 (lang dune 3.18)
 (generate_opam_files true)
-(allow_approximate_merlin)
 
 (name repr)
 (source (github mirage/repr))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.18)
 (generate_opam_files true)
 (allow_approximate_merlin)
 
@@ -7,6 +7,7 @@
 (license ISC)
 (authors "Thomas Gazagnaire" "Craig Ferguson")
 (maintainers "thomas@gazagnaire.org")
+(maintenance_intent "(latest)")
 
 (package
  (name repr)

--- a/ppx_repr.opam
+++ b/ppx_repr.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/repr"
 doc: "https://mirage.github.io/repr"
 bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.18"}
   "repr" {= version}
   "ppxlib" {>= "0.36.2"}
   "ppx_deriving"
@@ -37,3 +37,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/repr.git"
+x-maintenance-intent: ["(latest)"]

--- a/repr-bench.opam
+++ b/repr-bench.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/repr"
 doc: "https://mirage.github.io/repr"
 bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.18"}
   "repr" {= version}
   "ppx_repr" {= version}
   "bechamel"
@@ -32,3 +32,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/repr.git"
+x-maintenance-intent: ["(latest)"]

--- a/repr-fuzz.opam
+++ b/repr-fuzz.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/repr"
 doc: "https://mirage.github.io/repr"
 bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.18"}
   "repr" {= version}
   "crowbar" {= "0.2"}
   "ppxlib" {>= "0.36.2"}
@@ -30,3 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/repr.git"
+x-maintenance-intent: ["(latest)"]

--- a/repr.opam
+++ b/repr.opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/mirage/repr"
 doc: "https://mirage.github.io/repr"
 bug-reports: "https://github.com/mirage/repr/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.08.0"}
   "fmt" {>= "0.8.7"}
   "uutf"
@@ -41,3 +41,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mirage/repr.git"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This adds an `x-maintenance-intent` following https://github.com/ocaml/opam-repository/pull/28963

Since opam-files are generated from `dune-project` I've added it there and regenerated the opam-files.
Doing so however requires dune.3.18, so I've had to bump its lower bound.
(adding 4 template-files instead this bump could be avoided)

While rebuilding opam-files I got a warning about a now useless field, so the second commit removes that:
```
Warning: This field was deprecated in version 2.8 of the dune language. It is
useless since the Merlin configurations are not ambiguous anymore.
```